### PR TITLE
Add support for github enterprise

### DIFF
--- a/doc/source/connections.rst
+++ b/doc/source/connections.rst
@@ -77,6 +77,11 @@ Create a connection with GitHub.
   Path to SSH key to use when cloning github repositories.
   ``sshkey=/home/zuul/.ssh/id_rsa``
 
+**git_host**
+  Optional: Hostname of the github install (such as a GitHub Enterprise)
+  If not specified, defaults to ``github.com``
+  ``git_host=github.myenterprise.com``
+
 SMTP
 ----
 


### PR DESCRIPTION
GitHub enterprise just requires setting a git_host to something other
than the default of 'github.com'. If this host is set to something else,
perform an enterprise_login() instead of a login(). All other activity
appears to be the same.

A more complete change would be allowing clone/push using the API key
instead of the ssh key, which would reduce the amount of credentials one
must manage on the zuul host.

This change does not add tests.