### PR TITLE
Add github reporter status_url config option

### DIFF
--- a/doc/source/reporters.rst
+++ b/doc/source/reporters.rst
@@ -44,6 +44,10 @@ reporter. It has the following options.
   set commit status on github. Defaults to ``false``.
   ``commit_status=true``
 
+  **status_url**
+  String value for a link url to give to the github status. Defaults to the
+  zuul server status url, or the empty sting if that is unset.
+
   **comment**
   Boolean value (``true`` or ``false``) that determines if the reporter should
   add a comment with the pipeline status to the github pull request.

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -61,9 +61,14 @@ pipelines:
     success:
       github:
         comment: false
+        status: true
+        status_url: http://logs.example.com/{change.project.name}/{change.number}/{change.patchset}
     failure:
       github:
         comment: false
+        status: true
+        status_url: http://logs.example.com/{change.project.name}/{change.number}/{change.patchset}
+
 
   - name: merge
     description: Pipeline for merging the pull request


### PR DESCRIPTION
Make it possible to set the github status link to something other than the
zuul-server status url. This allows the github status to link to the log output
for the jobs. If set, this url will be run through the same formatter
as the url_pattern used for comment links. If unset, it will fall back to the
previous behaviour of using the zuul_server status_url.

Also make the github reporter report() function take the same argument list as
the abstract base class.

Change-Id: I5f2ff35bb38426ddcd7f65798b4f114256a54847