### PR TITLE
Add trigger capability on github pr review

### DIFF
--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -124,6 +124,8 @@ following options.
 
     *pr-label* - label added or removed on pull request
 
+    *pr-review* - review added on pull request
+
     *push* - head reference updated (pushed to branch)
 
     *tag* - new tag created
@@ -155,6 +157,11 @@ following options.
   match when pull request is labeled with a ``recheck`` label. ``label: '-do
   not test'`` will match when a label with name ``do not test`` is removed from
   the pull request.
+
+  **state**
+  This is only used for ``pr-review`` events.  It accepts a list of strings
+  each of which is matched to the review state, which can be one of
+  ``approved``, ``comment``, or ``request_changes``.
 
 
 GitHub Configuration

--- a/tests/base.py
+++ b/tests/base.py
@@ -546,6 +546,36 @@ class FakeGithubPullRequest(object):
         }
         return (name, data)
 
+    def getReviewAddedEvent(self, review):
+        name = 'pull_request_review'
+        data = {
+            'action': 'submitted',
+            'pull_request': {
+                'number': self.number,
+                'title': self.subject,
+                'updated_at': self.updated_at,
+                'base': {
+                    'ref': self.branch,
+                    'repo': {
+                        'full_name': self.project
+                    }
+                },
+                'head': {
+                    'sha': self.head_sha
+                }
+            },
+            'review': {
+                'state': review
+            },
+            'repository': {
+                'full_name': self.project
+            },
+            'sender': {
+                'login': 'ghuser'
+            }
+        }
+        return (name, data)
+
     def addLabel(self, name):
         if name not in self.labels:
             self.labels.append(name)

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -114,6 +114,21 @@ pipelines:
       github:
         - event: tag
 
+  - name: reviews
+    description: Trigger on review
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: pr-review
+          state: 'approve'
+
+    success:
+      github:
+        label:
+          - 'tests passed'
+          - '-test'
+
 jobs:
   - name: ^.*-merge$
     failure-message: Unable to merge change
@@ -142,6 +157,8 @@ projects:
       - project-test1
     labels:
       - project-labels
+    reviews:
+      - project-reviews
 
   - name: org/one-job-project
     check:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -177,6 +177,20 @@ class TestGithub(ZuulTestCase):
         self.assertEqual(0, len(self.history))
         self.assertEqual(['other label'], A.labels)
 
+    def test_review_event(self):
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getReviewAddedEvent('approve'))
+        self.waitUntilSettled()
+        self.assertEqual(1, len(self.history))
+        self.assertEqual('project-reviews', self.history[0].name)
+        self.assertEqual(['tests passed'], A.labels)
+
+    def test_review_unmatched_event(self):
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getReviewAddedEvent('comment'))
+        self.waitUntilSettled()
+        self.assertEqual(0, len(self.history))
+
     def test_dequeue_pull_synchronized(self):
         self.worker.hold_jobs_in_build = True
 

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -165,6 +165,26 @@ class GithubWebhookListener():
         event.type = 'pr-comment'
         return event
 
+    def _event_pull_request_review(self, request):
+        """Handles pull request reviews"""
+        body = request.json_body
+        action = body.get('action')
+        if action != 'submitted':
+            return
+        pr_body = body.get('pull_request')
+        if pr_body is None:
+            return
+
+        review = body.get('review')
+        if review is None:
+            return
+
+        event = self._pull_request_to_event(pr_body)
+        event.state = review.get('state')
+        event.account = self._get_sender(body)
+        event.type = 'pr-review'
+        return event
+
     def _issue_to_pull_request(self, body):
         number = body.get('issue').get('number')
         project_name = body.get('repository').get('full_name')

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -1091,6 +1091,7 @@ class TriggerEvent(object):
         self.branch = None
         self.comment = None
         self.label = None
+        self.state = None
         # ref-updated
         self.ref = None
         self.oldrev = None
@@ -1232,7 +1233,7 @@ class EventFilter(BaseFilter):
     def __init__(self, trigger, types=[], branches=[], refs=[],
                  event_approvals={}, comments=[], emails=[], usernames=[],
                  timespecs=[], required_approvals=[], reject_approvals=[],
-                 pipelines=[], labels=[], ignore_deletes=True):
+                 pipelines=[], labels=[], states=[], ignore_deletes=True):
         super(EventFilter, self).__init__(
             required_approvals=required_approvals,
             reject_approvals=reject_approvals)
@@ -1254,6 +1255,7 @@ class EventFilter(BaseFilter):
         self.event_approvals = event_approvals
         self.timespecs = timespecs
         self.labels = labels
+        self.states = states
         self.ignore_deletes = ignore_deletes
 
     def __repr__(self):
@@ -1288,6 +1290,8 @@ class EventFilter(BaseFilter):
             ret += ' timespecs: %s' % ', '.join(self.timespecs)
         if self.labels:
             ret += ' labels: %s' % ', '.join(self.labels)
+        if self.states:
+            ret += ' states: %s' % ', '.join(self.states)
         ret += '>'
 
         return ret
@@ -1386,6 +1390,10 @@ class EventFilter(BaseFilter):
 
         # labels are ORed
         if self.labels and event.label not in self.labels:
+            return False
+
+        # states are ORed
+        if self.states and event.state not in self.states:
             return False
 
         return True

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -38,7 +38,8 @@ class GithubTrigger(BaseTrigger):
                 branches=toList(trigger.get('branch')),
                 refs=toList(trigger.get('ref')),
                 comments=toList(trigger.get('comment')),
-                labels=toList(trigger.get('label'))
+                labels=toList(trigger.get('label')),
+                states=toList(trigger.get('state'))
             )
             efilters.append(f)
 
@@ -60,6 +61,7 @@ def getSchema():
                      'pr-reopen',
                      'pr-comment',
                      'pr-label',
+                     'pr-review',
                      'push',
                      'tag',
                      )),
@@ -67,6 +69,7 @@ def getSchema():
         'ref': toList(str),
         'comment': toList(str),
         'label': toList(str),
+        'state': toList(str),
     }
 
     logging.debug("github_trigger")


### PR DESCRIPTION
A github pull request review is a new type of event that happens when
user provides a review of a pull request
https://developer.github.com/v3/pulls/reviews

It will create an event
https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
sent to the webhook. Initially allow for filtering on the review state,
which can be one of three choices.

Change-Id: If94c2fe8adbe18fa7f426d5462559ba24963424c
(cherry picked from commit b68be427451fcf700cb2a65501b027272d75cd01)

Closes BonnyCI/projman#73