### PR TITLE
Add support for requiring github pr head status

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -503,13 +503,11 @@ class FakeGithubPullRequest(object):
         """Adds a commit on top of the actual PR head."""
         self._addCommitToRepo(files=files)
         self._updateTimeStamp()
-        self._clearStatuses()
 
     def forcePush(self, files=[]):
         """Clears actual commits and add a commit on top of the base."""
         self._addCommitToRepo(files=files, reset=True)
         self._updateTimeStamp()
-        self._clearStatuses()
 
     def getPullRequestOpenedEvent(self):
         return self._getPullRequestEvent('opened')
@@ -573,7 +571,10 @@ class FakeGithubPullRequest(object):
                     }
                 },
                 'head': {
-                    'sha': self.head_sha
+                    'sha': self.head_sha,
+                    'repo': {
+                        'full_name': self.project
+                    }
                 }
             },
             'label': {
@@ -620,6 +621,9 @@ class FakeGithubPullRequest(object):
         repo.index.add([fn])
 
         self.head_sha = repo.index.commit(msg).hexsha
+        # Create an empty set of statuses for the given sha,
+        # each sha on a PR may have a status set on it
+        self.statuses[self.head_sha] = []
         repo.head.reference = 'master'
         zuul.merger.merger.reset_repo_to_head(repo)
         repo.git.clean('-x', '-f', '-d')
@@ -632,15 +636,21 @@ class FakeGithubPullRequest(object):
         repo = self._getRepo()
         return repo.references[self._getPRReference()].commit.hexsha
 
-    def setStatus(self, state, url, description, context):
-        self.statuses[context] = {
+    def setStatus(self, sha, state, url, description, context):
+        # Since we're bypassing github API, which would require a user, we
+        # hard set the user as 'zuul' here.
+        user = 'zuul'
+        # insert the status at the top of the list, to simulate that it
+        # is the most recent set status
+        self.statuses[sha].insert(0, ({
             'state': state,
             'url': url,
-            'description': description
-        }
-
-    def _clearStatuses(self):
-        self.statuses = {}
+            'description': description,
+            'context': context,
+            'creator': {
+                'login': user
+            }
+        }))
 
     def _getPRReference(self):
         return '%s/head' % self.number
@@ -661,7 +671,10 @@ class FakeGithubPullRequest(object):
                     }
                 },
                 'head': {
-                    'sha': self.head_sha
+                    'sha': self.head_sha,
+                    'repo': {
+                        'full_name': self.project
+                    }
                 }
             },
             'sender': {
@@ -747,7 +760,10 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
                 'ref': pr.branch,
             },
             'head': {
-                'sha': pr.head_sha
+                'sha': pr.head_sha,
+                'repo': {
+                    'full_name': pr.project
+                }
             }
         }
         return data
@@ -786,13 +802,20 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         pull_request.is_merged = True
         pull_request.merge_message = commit_message
 
+    def getCommitStatuses(self, owner, project, sha):
+        for pr in self.pull_requests:
+            pr_owner, pr_project = pr.project.split('/')
+            if (pr_owner == owner and pr_project == project and
+                pr.head_sha == sha):
+                return pr.statuses[sha]
+
     def setCommitStatus(self, owner, project, sha, state,
                         url='', description='', context=''):
         for pr in self.pull_requests:
             pr_owner, pr_project = pr.project.split('/')
             if (pr_owner == owner and pr_project == project and
                 pr.head_sha == sha):
-                pr.setStatus(state, url, description, context)
+                pr.setStatus(sha, state, url, description, context)
 
     def labelPull(self, owner, project, pr_number, label):
         pull_request = self.pull_requests[pr_number - 1]

--- a/tests/fixtures/layout-github-requirement-status.yaml
+++ b/tests/fixtures/layout-github-requirement-status.yaml
@@ -1,0 +1,36 @@
+pipelines:
+  - name: pipeline
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      status: "zuul:check:success"
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+#  - name: trigger
+#    manager: IndependentPipelineManager
+#    trigger:
+#      github:
+#        - event: pr-comment
+#          comment: 'test me'
+#          require-approval:
+#            - username: zuul
+#    success:
+#      github:
+#        comment: true
+#    failure:
+#      github:
+#        status: true
+
+projects:
+  - name: org/project1
+    pipeline:
+      - project1-pipeline
+#  - name: org/project2
+#    trigger:
+#      - project2-trigger

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -232,10 +232,14 @@ class TestGithub(ZuulTestCase):
         A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
         self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
         self.waitUntilSettled()
-        self.assertIn('check', A.statuses)
-        check_status = A.statuses['check']
+        # We should have a status container for the head sha
+        self.assertIn(A.head_sha, A.statuses.keys())
+        # We should only have one status for the head sha
+        self.assertEqual(1, len(A.statuses[A.head_sha]))
+        check_status = A.statuses[A.head_sha][0]
         check_url = ('http://zuul.example.com/status/#%s,%s' %
                      (A.number, A.head_sha))
+        self.assertEqual('check', check_status['context'])
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('pending', check_status['state'])
         self.assertEqual(check_url, check_status['url'])
@@ -243,9 +247,12 @@ class TestGithub(ZuulTestCase):
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
-        check_status = A.statuses['check']
+        # We should only have two statuses for the head sha
+        self.assertEqual(2, len(A.statuses[A.head_sha]))
+        check_status = A.statuses[A.head_sha][0]
         check_url = ('http://zuul.example.com/status/#%s,%s' %
                      (A.number, A.head_sha))
+        self.assertEqual('check', check_status['context'])
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('success', check_status['state'])
         self.assertEqual(check_url, check_status['url'])
@@ -255,18 +262,20 @@ class TestGithub(ZuulTestCase):
         self.fake_github.emitEvent(
             A.getCommentAddedEvent('reporting check'))
         self.waitUntilSettled()
-        # pipeline does not report start status
-        self.assertNotIn('reporting', A.statuses)
+        # pipeline does not report start status, we should only have 2
+        self.assertEqual(2, len(A.statuses[A.head_sha]))
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
         # pipeline reports success/failure status
-        self.assertIn('reporting', A.statuses)
-        report_status = A.statuses['reporting']
+        self.assertEqual(3, len(A.statuses[A.head_sha]))
+        report_status = A.statuses[A.head_sha][0]
         status_url = report_status['url']
         expected_url = ('http://logs.example.com/org/project/1/%s' %
                         A.head_sha)
         self.assertEqual(expected_url, status_url)
+        self.assertEqual('reporting', report_status['context'])
+        self.assertEqual('success', report_status['state'])
 
     def test_report_pull_comment(self):
         # pipeline reports comment on success

--- a/tests/test_github_requirements.py
+++ b/tests/test_github_requirements.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2016 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from tests.base import ZuulTestCase
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s %(name)-32s '
+                    '%(levelname)-8s %(message)s')
+
+
+class TestGithubRequirements(ZuulTestCase):
+    """Test pipeline and trigger requirements"""
+
+    def setup_config(self, config_file='zuul-github.conf'):
+        super(TestGithubRequirements, self).setup_config(config_file)
+
+    def test_pipeline_require_status(self):
+        "Test pipeline requirement: status"
+        return self._test_require_status('org/project1',
+                                         'project1-pipeline')
+
+#    def test_trigger_require_status(self):
+#        "Test trigger requirement: status"
+#        return self._test_require_status('org/project2',
+#                                         'project2-trigger')
+
+    def _test_require_status(self, project, job):
+        self.config.set('zuul', 'layout_config',
+                        'tests/fixtures/layout-github-requirement-status.yaml')
+        self.sched.reconfigure(self.config)
+        self.registerJobs()
+
+        A = self.fake_github.openFakePullRequest(project, 'master', 'A')
+        # A comment event that we will keep submitting to trigger
+        comment = A.getCommentAddedEvent('test me')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        # No status from zuul so should not be enqueued
+        self.assertEqual(len(self.history), 0)
+
+        # An error status should not cause it to be enqueued
+        A.setStatus(A.head_sha, 'error', 'null', 'null', 'check')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A success status goes in
+        A.setStatus(A.head_sha, 'success', 'null', 'null', 'check')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 1)
+        self.assertEqual(self.history[0].name, job)
+
+# TODO: Implement reject on status

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -220,7 +220,31 @@ class GithubWebhookListener():
 
         event.title = pr_body.get('title')
 
+        # get the statuses
+        owner, project = event.project_name.split('/')
+        event.statuses = self._get_statuses(owner, project, event.patch_number)
+
         return event
+
+    def _get_statuses(self, owner, project, sha):
+        # A ref can have more than one status from each context,
+        # however the API returns them in order, newest first.
+        # So we can keep track of which contexts we've already seen
+        # and throw out the rest. Our unique key is based on
+        # the user and the context, since context is free form and anybody
+        # can put whatever they want there. We want to ensure we track it
+        # by user, so that we can require/trigger by user too.
+        seen = []
+        statuses = []
+        for status in self.connection.getCommitStatuses(owner, project, sha):
+            user = status.get('creator').get('login')
+            context = status.get('context')
+            state = status.get('state')
+            if "%s:%s" % (user, context) not in seen:
+                statuses.append("%s:%s:%s" % (user, context, state))
+                seen.append("%s:%s" % (user, context))
+
+        return statuses
 
     def _get_sender(self, body):
         login = body.get('sender').get('login')
@@ -424,6 +448,16 @@ class GithubConnection(BaseConnection):
         log_rate_limit(self.log, self.github)
         if not result:
             raise Exception('Pull request was not merged')
+
+    def getCommitStatuses(self, owner, project, sha):
+        repository = self.github.repository(owner, project)
+        commit = repository.commit(sha)
+        # make a list out of the statuses so that we complete our
+        # API transaction
+        statuses = [status for status in commit.statuses()]
+
+        log_rate_limit(self.log, self.github)
+        return statuses
 
     def setCommitStatus(self, owner, project, sha, state,
                         url='', description='', context=''):

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -1431,8 +1431,19 @@ class ChangeishFilter(BaseFilter):
                 return False
 
         if self.statuses:
-            if change.status not in self.statuses:
-                return False
+            # handle a change where status is list of statuses rather
+            # than a single string
+            if not isinstance(change.status, list):
+                if change.status not in self.statuses:
+                    return False
+            else:
+                # this is likely from github, where the head of the
+                # pr can have multiple statues on it.
+                # If the change statuses and the filter statuses are
+                # a null intersection, there are no matches and we return
+                # false.
+                if set(change.status).isdisjoint(set(self.statuses)):
+                    return False
 
         # required approvals are ANDed (reject approvals are ORed)
         if not self.matchesApprovals(change):

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -60,6 +60,7 @@ class GithubSource(BaseSource):
             change.patchset = event.patch_number
             change.files = self.getPullFiles(project, change.number)
             change.title = event.title
+            change.status = event.statuses
             change.source_event = event
         else:
             change = Ref(project)


### PR DESCRIPTION
This hooks into what exists for gerrit, a requiremnt on status. However
it slightly modifies the model so that the change status could be a list
or a str, as GitHub commits can have more than one status.

When creating a github pull request object, the statuses of the head
commit are fetched, and the latest status of each context is appended
into a list of statuses. The string is 'context:state', where state can
be success, error, or failure. Context is freeform.

Tests have been added to validate that requirements on github based
pipelines are honored.

Tests that would handle trigger requirements are commented out, as we do
not yet support triggering on status, so we can't test filtering that to
only trigger on status from particular context:state.

closes BonnyCI/projman#75

Change-Id: I45abbd6cbddd36b8491bdf9bb8d545216537ad2f
Signed-off-by: Jesse Keating <omgjlk@us.ibm.com>