### PR TITLE
Adds ability to trigger events from commit status changes

### DIFF
--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -130,6 +130,8 @@ following options.
 
     *tag* - new tag created
 
+    *status* - status set on commit
+
   **branch**
   The branch associated with the event. Example: ``master``.  This
   field is treated as a regular expression, and multiple branches may
@@ -163,6 +165,11 @@ following options.
   each of which is matched to the review state, which can be one of
   ``approved``, ``comment``, or ``request_changes``.
 
+  **status**
+  This is only used for ``status`` events. It accepts a list of strings each of
+  which matches the user setting the status, the status context, and the status
+  itself in the format of ``user:context:status``.  For example,
+  ``zuul_github_ci_bot:check_pipeline:success``.
 
 GitHub Configuration
 ~~~~~~~~~~~~~~~~~~~~

--- a/tests/base.py
+++ b/tests/base.py
@@ -666,10 +666,9 @@ class FakeGithubPullRequest(object):
         repo = self._getRepo()
         return repo.references[self._getPRReference()].commit.hexsha
 
-    def setStatus(self, sha, state, url, description, context):
+    def setStatus(self, sha, state, url, description, context, user='zuul'):
         # Since we're bypassing github API, which would require a user, we
         # hard set the user as 'zuul' here.
-        user = 'zuul'
         # insert the status at the top of the list, to simulate that it
         # is the most recent set status
         self.statuses[sha].insert(0, ({
@@ -709,6 +708,21 @@ class FakeGithubPullRequest(object):
             },
             'sender': {
                 'login': 'ghuser'
+            }
+        }
+        return (name, data)
+
+    def getCommitStatusEvent(self, context, state='success', user='zuul'):
+        name = 'status'
+        data = {
+            'state': state,
+            'sha': self.head_sha,
+            'description': 'Test results for %s: %s' % (self.head_sha, state),
+            'target_url': 'http://zuul/%s' % self.head_sha,
+            'branches': [],
+            'context': context,
+            'sender': {
+                'login': user
             }
         }
         return (name, data)
@@ -797,6 +811,14 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
             }
         }
         return data
+
+    def getPullBySha(self, sha):
+        prs = list(set([p for p in self.pull_requests if sha == p.head_sha]))
+        if len(prs) > 1:
+            raise Exception('Multiple pulls found with head sha: %s' % sha)
+        pr = prs[0]
+        owner, project = pr.project.split('/')
+        return self.getPull(owner, project, pr.number)
 
     def getPullFileNames(self, owner, project, number):
         pr = self.pull_requests[number - 1]

--- a/tests/fixtures/layout-github-requirement-status.yaml
+++ b/tests/fixtures/layout-github-requirement-status.yaml
@@ -12,25 +12,24 @@ pipelines:
       github:
         comment: true
 
-#  - name: trigger
-#    manager: IndependentPipelineManager
-#    trigger:
-#      github:
-#        - event: pr-comment
-#          comment: 'test me'
-#          require-approval:
-#            - username: zuul
-#    success:
-#      github:
-#        comment: true
-#    failure:
-#      github:
-#        status: true
+  - name: trigger
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: status
+          status: 'zuul:check:success'
+    success:
+      github:
+        comment: true
+    failure:
+      github:
+        status: true
 
 projects:
   - name: org/project1
     pipeline:
       - project1-pipeline
-#  - name: org/project2
-#    trigger:
-#      - project2-trigger
+  - name: org/project2
+    trigger:
+      - project2-trigger

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -39,7 +39,8 @@ class GithubTrigger(BaseTrigger):
                 refs=toList(trigger.get('ref')),
                 comments=toList(trigger.get('comment')),
                 labels=toList(trigger.get('label')),
-                states=toList(trigger.get('state'))
+                states=toList(trigger.get('state')),
+                statuses=toList(trigger.get('status'))
             )
             efilters.append(f)
 
@@ -63,6 +64,7 @@ def getSchema():
                      'pr-label',
                      'pr-review',
                      'push',
+                     'status',
                      'tag',
                      )),
         'branch': toList(str),
@@ -70,6 +72,7 @@ def getSchema():
         'comment': toList(str),
         'label': toList(str),
         'state': toList(str),
+        'status': toList(str)
     }
 
     logging.debug("github_trigger")


### PR DESCRIPTION
This adds support for triggering on github status updates.

The status matching logic was moved out of the ChangeishFilter
and into BaseFilter so it can also be used by EventFilters.  Config
schema for the github trigger has been updated to accept a list of
statuses, in the "github_user:context:status" format.

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>