### PR TITLE
Implement pipeline requirement on github reviews

### DIFF
--- a/doc/source/zuul.rst
+++ b/doc/source/zuul.rst
@@ -455,6 +455,19 @@ explanation of each of the parameters::
     be a single value or a list: ``verified: [1, 2]`` would match
     either a +1 or +2 vote.
 
+    A note on GitHub; GitHub supports pull-request reviews. These
+    can be provided by anybody with read access to a repository. A
+    review may approve, request changes, or simply comment on the
+    change. Within Zuul these reviews are mapped to appear like an
+    approval. An ``approve`` or ``request_changes`` review is mapped
+    to a category of ``review``, whereas a ``comment`` review is
+    mapped to a category of ``comment``. If a reviewer has write
+    access to the repository in question, their review is given a
+    value of ``2`` or ``-2`` for ``approve`` or ``request_changes``
+    respectfully. Reviewers with only read access are assigned a
+    value of ``1`` or ``-1``. All ``comment`` reviews are given a
+    value of ``0``.
+
   **open**
   A boolean value (``true`` or ``false``) that indicates whether the change
   must be open or closed in order to be enqueued.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 pbr>=1.1.0
 
-Github3.py==1.0.0a2
+# pull from master until https://github.com/sigmavirus24/github3.py/pull/671
+# is in a release
+-e git://github.com/sigmavirus24/github3.py.git@develop#egg=Github3.py
 PyYAML>=3.1.0
 Paste<2.0
 WebOb>=1.2.3

--- a/tests/base.py
+++ b/tests/base.py
@@ -477,7 +477,8 @@ class GithubChangeReference(git.Reference):
 class FakeGithubPullRequest(object):
 
     def __init__(self, github, number, project, branch,
-                 subject, upstream_root, files=[], number_of_commits=1):
+                 subject, upstream_root, files=[], number_of_commits=1,
+                 writers=[]):
         """Creates a new PR with several commits.
         Sends an event about opened PR."""
         self.github = github
@@ -491,6 +492,8 @@ class FakeGithubPullRequest(object):
         self.comments = []
         self.labels = []
         self.statuses = {}
+        self.reviews = []
+        self.writers = []
         self.updated_at = None
         self.head_sha = None
         self.is_merged = False
@@ -681,6 +684,24 @@ class FakeGithubPullRequest(object):
             }
         }))
 
+    def addReview(self, user, state, granted_on=None):
+        # Each user will only have one review at a time, so replace
+        # any existing reviews
+        for review in self.reviews:
+            if review['user']['login'] == user:
+                self.reviews.remove(review)
+
+        if not granted_on:
+            granted_on = time.time()
+        self.reviews.append({
+            'state': state,
+            'user': {
+                'login': user,
+                'email': user + "@derp.com",
+            },
+            'provided': int(granted_on),
+        })
+
     def _getPRReference(self):
         return '%s/head' % self.number
 
@@ -824,6 +845,10 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         pr = self.pull_requests[number - 1]
         return pr.files
 
+    def getPullReviews(self, owner, project, number):
+        pr = self.pull_requests[number - 1]
+        return pr.reviews
+
     def getUser(self, login):
         data = {
             'username': login,
@@ -831,6 +856,15 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
             'email': 'github.user@example.com'
         }
         return data
+
+    def getRepoPermission(self, owner, project, login):
+        for pr in self.pull_requests:
+            pr_owner, pr_project = pr.project.split('/')
+            if (pr_owner == owner and pr_project):
+                if login in pr.writers:
+                    return 'write'
+                else:
+                    return 'read'
 
     def getGitUrl(self, project):
         return os.path.join(self.upstream_root, str(project))

--- a/tests/fixtures/layout-github-requirement-state.yaml
+++ b/tests/fixtures/layout-github-requirement-state.yaml
@@ -1,0 +1,37 @@
+pipelines:
+  - name: pipeline
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - review: 2
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+#  - name: trigger
+#    manager: IndependentPipelineManager
+#    trigger:
+#      github:
+#        - event: pr-comment
+#          comment: 'test me'
+#          require-approval:
+#            - username: zuul
+#    success:
+#      github:
+#        comment: true
+#    failure:
+#      github:
+#        status: true
+
+projects:
+  - name: org/project1
+    pipeline:
+      - project1-pipeline
+#  - name: org/project2
+#    trigger:
+#      - project2-trigger

--- a/tests/fixtures/layout-github-requirement-username-state.yaml
+++ b/tests/fixtures/layout-github-requirement-username-state.yaml
@@ -1,0 +1,38 @@
+pipelines:
+  - name: pipeline
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - username: derp
+          review: 2
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+#  - name: trigger
+#    manager: IndependentPipelineManager
+#    trigger:
+#      github:
+#        - event: pr-comment
+#          comment: 'test me'
+#          require-approval:
+#            - username: zuul
+#    success:
+#      github:
+#        comment: true
+#    failure:
+#      github:
+#        status: true
+
+projects:
+  - name: org/project1
+    pipeline:
+      - project1-pipeline
+#  - name: org/project2
+#    trigger:
+#      - project2-trigger

--- a/tests/fixtures/layout-github-requirement-username.yaml
+++ b/tests/fixtures/layout-github-requirement-username.yaml
@@ -1,0 +1,37 @@
+pipelines:
+  - name: pipeline
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - username: ^(herp|derp)$
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+#  - name: trigger
+#    manager: IndependentPipelineManager
+#    trigger:
+#      github:
+#        - event: pr-comment
+#          comment: 'test me'
+#          require-approval:
+#            - username: zuul
+#    success:
+#      github:
+#        comment: true
+#    failure:
+#      github:
+#        status: true
+
+projects:
+  - name: org/project1
+    pipeline:
+      - project1-pipeline
+#  - name: org/project2
+#    trigger:
+#      - project2-trigger

--- a/tests/test_github_requirements.py
+++ b/tests/test_github_requirements.py
@@ -72,16 +72,150 @@ class TestGithubRequirements(ZuulTestCase):
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
-        # An success status from unknown user should not cause it to be
+        # A success status from unknown user should not cause it to be
         # enqueued
-        A.setStatus(A.head_sha, 'error', 'null', 'null', 'check', user='foo')
+        A.setStatus(A.head_sha, 'success', 'null', 'null', 'check', user='foo')
         self.fake_github.emitEvent(A.getCommitStatusEvent('error'))
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
-        # A success status goes in
+        # A success status from zuul goes in
         A.setStatus(A.head_sha, 'success', 'null', 'null', 'check')
         self.fake_github.emitEvent(A.getCommitStatusEvent('success'))
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 1)
         self.assertEqual(self.history[0].name, 'project2-trigger')
+
+# TODO: Implement reject on status
+
+    def test_pipeline_require_approval_username(self):
+        "Test pipeline requirement: approval username"
+        return self._test_require_approval_username('org/project1',
+                                                    'project1-pipeline')
+
+
+#    def test_trigger_require_approval_username(self):
+#        "Test pipeline requirement: approval username"
+#        return self._test_require_approval_username('org/project2',
+#                                                    'project2-trigger')
+
+    def _test_require_approval_username(self, project, job):
+        self.config.set(
+            'zuul', 'layout_config',
+            'tests/fixtures/layout-github-requirement-username.yaml')
+        self.sched.reconfigure(self.config)
+        self.registerJobs()
+
+        A = self.fake_github.openFakePullRequest(project, 'master', 'A')
+        # A comment event that we will keep submitting to trigger
+        comment = A.getCommentAddedEvent('test me')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        # No approval from derp so should not be enqueued
+        self.assertEqual(len(self.history), 0)
+
+        # Add an approval (review) from derp
+        A.addReview('derp', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 1)
+        self.assertEqual(self.history[0].name, job)
+
+    def test_pipeline_require_approval_state(self):
+        "Test pipeline requirement: approval state"
+        return self._test_require_approval_state('org/project1',
+                                                 'project1-pipeline')
+
+#    def test_trigger_require_approval_state(self):
+#        "Test pipeline requirement: approval state"
+#        return self._test_require_approval_state('org/project2',
+#                                                 'project2-trigger')
+
+    def _test_require_approval_state(self, project, job):
+        self.config.set('zuul', 'layout_config',
+                        'tests/fixtures/layout-github-requirement-state.yaml')
+        self.sched.reconfigure(self.config)
+        self.registerJobs()
+
+        A = self.fake_github.openFakePullRequest(project, 'master', 'A')
+        # Add derp to writers
+        A.writers.append('derp')
+        # A comment event that we will keep submitting to trigger
+        comment = A.getCommentAddedEvent('test me')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        # No positive approval from derp so should not be enqueued
+        self.assertEqual(len(self.history), 0)
+
+        # A -2 from derp should not cause it to be enqueued
+        A.addReview('derp', 'REQUEST_CHANGES')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +1 from nobody should not cause it to be enqueued
+        A.addReview('nobody', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +2 from derp should cause it to be enqueued
+        A.addReview('derp', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 1)
+        self.assertEqual(self.history[0].name, job)
+
+    def test_pipeline_require_approval_user_state(self):
+        "Test pipeline requirement: approval state from user"
+        return self._test_require_approval_user_state('org/project1',
+                                                      'project1-pipeline')
+
+#    def test_trigger_require_approval_user_state(self):
+#        "Test pipeline requirement: approval state from user"
+#        return self._test_require_approval_user_state('org/project2',
+#                                                      'project2-trigger')
+
+    def _test_require_approval_user_state(self, project, job):
+        self.config.set(
+            'zuul', 'layout_config',
+            'tests/fixtures/layout-github-requirement-username-state.yaml')
+        self.sched.reconfigure(self.config)
+        self.registerJobs()
+
+        A = self.fake_github.openFakePullRequest(project, 'master', 'A')
+        # Add derp and herp to writers
+        A.writers.extend(('derp', 'herp'))
+        # A comment event that we will keep submitting to trigger
+        comment = A.getCommentAddedEvent('test me')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        # No positive approval from derp so should not be enqueued
+        self.assertEqual(len(self.history), 0)
+
+        # A -2 from derp should not cause it to be enqueued
+        A.addReview('derp', 'REQUEST_CHANGES')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +1 from nobody should not cause it to be enqueued
+        A.addReview('nobody', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +2 from herp should not cause it to be enqueued
+        A.addReview('herp', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +2 from derp should cause it to be enqueued
+        A.addReview('derp', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 1)
+        self.assertEqual(self.history[0].name, job)
+
+# TODO: Implement reject on approval username/state


### PR DESCRIPTION
This shoves github reviews into the data model of gerrit approvals, so
that zuul can require them for pipeline. Users with push access provide
a 2/-2, others provide 1/-1.

Brings in an unreleased Github3.py code. Further extends that code to
determine if a user has push rights to a repository.

Closes BonnyCI/projman#74

Change-Id: I3ab2139c2b11b7dc8aa896a03047615bcf42adba
Signed-off-by: Jesse Keating <omgjlk@us.ibm.com>