### PR TITLE
Get commit status as a dict

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -474,7 +474,7 @@ class GithubConnection(BaseConnection):
         commit = repository.commit(sha)
         # make a list out of the statuses so that we complete our
         # API transaction
-        statuses = [status for status in commit.statuses()]
+        statuses = [status.as_dict() for status in commit.statuses()]
 
         log_rate_limit(self.log, self.github)
         return statuses


### PR DESCRIPTION
Making it a dict makes it easier to handle both real data from github
and fake data from tests (which is a dict).

Alternatively we could make a Status object from github3.py in the
tests, and somehow prevent it from connecting out, but that may be much
harder.

Closes BonnyCI/projman#100

Change-Id: I6aa78230f7ff3c4cca2f507cebe9a7f326f8fd08
Signed-off-by: Jesse Keating <omgjlk@us.ibm.com>