### PR TITLE
Fix tracebacks in status handling

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -456,7 +456,7 @@ class GithubConnection(BaseConnection):
 
     def getPullBySha(self, sha):
         query = '%s type:pr is:open' % sha
-        pulls = set()
+        pulls = []
         for issue in self.github.search_issues(query=query):
             pr_url = issue.pull_request.get('url')
             if not pr_url:
@@ -466,7 +466,9 @@ class GithubConnection(BaseConnection):
             pr = self.github.pull_request(owner, project, number)
             if pr.head.sha != sha:
                 continue
-            pulls.add(pr.as_dict())
+            if pr.as_dict() in pulls:
+                continue
+            pulls.append(pr.as_dict())
 
         if len(pulls) > 1:
             raise Exception('Multiple pulls found with head sha %s' % sha)


### PR DESCRIPTION
A search_issues call returns issue objects, which do not have a
'pull_request' attribute, instead they have an 'issue' attribute.

Dicts cannot be placed into sets, so just use a list instead.

Closes BonnyCI/projman#105

Change-Id: Ib4a32a646a22616f97041b8987fe9e5f109bed32