### PR TITLE
Call correct method for adding PR label

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -559,7 +559,7 @@ class GithubConnection(BaseConnection):
 
     def labelPull(self, owner, project, pr_number, label):
         pull_request = self.github.issue(owner, project, pr_number)
-        pull_request.add_label(label)
+        pull_request.add_labels(label)
         log_rate_limit(self.log, self.github)
 
     def unlabelPull(self, owner, project, pr_number, label):


### PR DESCRIPTION
The zuul github connection attempts to add labels to PRs by
calling a non-existent method, raising an AttributeError anytime
something merges in pipelines that are configured to add labels.
Unfortunately, this does not get exercised by existing tests.