### PR TITLE
Fix the gate, and filter PR reviews by the most recent per user 

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -15,6 +15,7 @@
 # under the License.
 
 from six.moves import configparser as ConfigParser
+import datetime
 import gc
 import hashlib
 import json
@@ -685,21 +686,37 @@ class FakeGithubPullRequest(object):
         }))
 
     def addReview(self, user, state, granted_on=None):
-        # Each user will only have one review at a time, so replace
-        # any existing reviews
-        for review in self.reviews:
-            if review['user']['login'] == user:
-                self.reviews.remove(review)
+        gh_time_format = '%Y-%m-%dT%H:%M:%SZ'
+        # convert the timestamp to a str format that would be returned
+        # from github as 'submitted_at' in the API response
 
-        if not granted_on:
-            granted_on = time.time()
+        if granted_on:
+            granted_on = datetime.datetime.utcfromtimestamp(granted_on)
+            submitted_at = time.strftime(
+                gh_time_format, granted_on.timetuple())
+        else:
+            # github timestamps only down to the second, so we need to make
+            # sure reviews that tests add appear to be added over a period of
+            # time in the past and not all at once.
+            if not self.reviews:
+                # the first review happens 10 mins ago
+                offset = 600
+            else:
+                # subsequent reviews happen 1 minute closer to now
+                offset = 600 - (len(self.reviews) * 60)
+
+            granted_on = datetime.datetime.utcfromtimestamp(
+                time.time() - offset)
+            submitted_at = time.strftime(
+                gh_time_format, granted_on.timetuple())
+
         self.reviews.append({
             'state': state,
             'user': {
                 'login': user,
                 'email': user + "@derp.com",
             },
-            'provided': int(granted_on),
+            'submitted_at': submitted_at,
         })
 
     def _getPRReference(self):

--- a/tests/fixtures/layout-github-requirement-newer-than.yaml
+++ b/tests/fixtures/layout-github-requirement-newer-than.yaml
@@ -1,0 +1,37 @@
+pipelines:
+  - name: newer_than
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - review: 2
+          newer-than: 1d
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+  - name: older_than
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - review: 2
+          older-than: 1d
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+projects:
+  - name: org/project1
+    newer_than:
+      - project1-pipeline
+  - name: org/project2
+    older_than:
+      - project2-pipeline

--- a/tests/fixtures/layout-github-requirement-state.yaml
+++ b/tests/fixtures/layout-github-requirement-state.yaml
@@ -5,6 +5,9 @@ pipelines:
     require:
       approval:
         - review: 2
+    reject:
+      approval:
+        - review: -2
     trigger:
       github:
         - event: pr-comment

--- a/tests/fixtures/layout-github-requirement-username-state.yaml
+++ b/tests/fixtures/layout-github-requirement-username-state.yaml
@@ -6,6 +6,9 @@ pipelines:
       approval:
         - username: derp
           review: 2
+    reject:
+       approval:
+         - review: -2
     trigger:
       github:
         - event: pr-comment

--- a/tests/test_github_requirements.py
+++ b/tests/test_github_requirements.py
@@ -16,6 +16,11 @@
 
 import logging
 
+from zuul.source.github import (
+    REVIEW_APPROVED,
+    REVIEW_CHANGES_REQUESTED,
+)
+
 from tests.base import ZuulTestCase
 
 logging.basicConfig(level=logging.DEBUG,
@@ -115,7 +120,7 @@ class TestGithubRequirements(ZuulTestCase):
         self.assertEqual(len(self.history), 0)
 
         # Add an approval (review) from derp
-        A.addReview('derp', 'APPROVE')
+        A.addReview('derp', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 1)
@@ -148,19 +153,19 @@ class TestGithubRequirements(ZuulTestCase):
         self.assertEqual(len(self.history), 0)
 
         # A -2 from derp should not cause it to be enqueued
-        A.addReview('derp', 'REQUEST_CHANGES')
+        A.addReview('derp', REVIEW_CHANGES_REQUESTED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +1 from nobody should not cause it to be enqueued
-        A.addReview('nobody', 'APPROVE')
+        A.addReview('nobody', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +2 from derp should cause it to be enqueued
-        A.addReview('derp', 'APPROVE')
+        A.addReview('derp', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 1)
@@ -194,25 +199,25 @@ class TestGithubRequirements(ZuulTestCase):
         self.assertEqual(len(self.history), 0)
 
         # A -2 from derp should not cause it to be enqueued
-        A.addReview('derp', 'REQUEST_CHANGES')
+        A.addReview('derp', REVIEW_CHANGES_REQUESTED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +1 from nobody should not cause it to be enqueued
-        A.addReview('nobody', 'APPROVE')
+        A.addReview('nobody', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +2 from herp should not cause it to be enqueued
-        A.addReview('herp', 'APPROVE')
+        A.addReview('herp', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +2 from derp should cause it to be enqueued
-        A.addReview('derp', 'APPROVE')
+        A.addReview('derp', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 1)

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -559,7 +559,7 @@ class GithubConnection(BaseConnection):
 
     def labelPull(self, owner, project, pr_number, label):
         pull_request = self.github.issue(owner, project, pr_number)
-        pull_request.add_label(label)
+        pull_request.add_labels(label)
         log_rate_limit(self.log, self.github)
 
     def unlabelPull(self, owner, project, pr_number, label):

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -19,6 +19,18 @@ from zuul.model import PullRequest, Ref
 from zuul.source import BaseSource
 
 
+# The reviews API is a developer preview.  These are the review states
+# we currently react to. See: https://developer.github.com/v3/pulls/reviews/
+REVIEW_APPROVED = 'APPROVED'
+REVIEW_CHANGES_REQUESTED = 'CHANGES_REQUESTED'
+REVIEW_COMMENTED = 'COMMENTED'
+REVIEW_STATES = [
+    REVIEW_APPROVED,
+    REVIEW_CHANGES_REQUESTED,
+    REVIEW_COMMENTED,
+]
+
+
 class GithubSource(BaseSource):
     name = 'github'
     log = logging.getLogger("zuul.GithubSource")
@@ -105,7 +117,7 @@ class GithubSource(BaseSource):
 
         approvals = []
         for review in reviews:
-            if review.get('state') == 'DISMISSED':
+            if review.get('state') not in REVIEW_STATES:
                 continue
 
             approval = {
@@ -117,7 +129,7 @@ class GithubSource(BaseSource):
             }
 
             # Determine type
-            if review.get('state') == 'COMMENTED':
+            if review.get('state') == REVIEW_COMMENTED:
                 approval['type'] = 'comment'
                 approval['description'] = 'comment'
                 approval['value'] = '0'
@@ -133,12 +145,12 @@ class GithubSource(BaseSource):
                 user_can_write = True
 
             # Determine value
-            if review.get('state') == 'APPROVED':
+            if review.get('state') == REVIEW_APPROVED:
                 if user_can_write:
                     approval['value'] = '2'
                 else:
                     approval['value'] = '1'
-            elif review.get('state') == 'CHANGES_REQUESTED':
+            elif review.get('state') == REVIEW_CHANGES_REQUESTED:
                 if user_can_write:
                     approval['value'] = '-2'
                 else:


### PR DESCRIPTION
This contains two fixes: One fixes a gate breaker that made it into the code base while our zuul mergers were down.  The other fixes the issue of older negative reviews trumping recent positive reviews for a user on a PR.