### PR TITLE
Comment on PRs if a remote call to merge a change failed

### DIFF
--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -74,6 +74,7 @@ pipelines:
     description: Pipeline for merging the pull request
     manager: IndependentPipelineManager
     source: github
+    merge-failure-message: 'Merge failed'
     trigger:
       github:
         - event: pr-comment

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -355,6 +355,8 @@ class TestGithub(ZuulTestCase):
         self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
         self.waitUntilSettled()
         self.assertFalse(A.is_merged)
+        self.assertEqual(len(A.comments), 1)
+        self.assertEqual(A.comments[0], 'Merge failed')
 
     def test_parallel_changes(self):
         "Test that changes are tested in parallel and merged in series"

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -58,11 +58,14 @@ class GithubReporter(BaseReporter):
         if (self._merge and
             hasattr(item.change, 'number')):
             self.mergePull(item)
+            if not item.change.is_merged:
+                msg = self._formatItemReportMergeFailure(pipeline, item)
+                self.addPullComment(pipeline, item, msg)
         if self._labels:
             self.setLabels(item)
 
-    def addPullComment(self, pipeline, item):
-        message = self._formatItemReport(pipeline, item)
+    def addPullComment(self, pipeline, item, comment=None):
+        message = comment or self._formatItemReport(pipeline, item)
         owner, project = item.change.project.name.split('/')
         pr_number = item.change.number
         self.log.debug(
@@ -106,13 +109,22 @@ class GithubReporter(BaseReporter):
         self.log.debug('Reporting change %s, params %s, merging via API' %
                        (item.change, self.reporter_config))
         message = self._formatMergeMessage(item.change)
-        try:
-            self.connection.mergePull(owner, project, pr_number, message, sha)
-        except MergeFailure:
-            time.sleep(2)
-            self.log.debug('Trying to merge change %s again...' % item.change)
-            self.connection.mergePull(owner, project, pr_number, message, sha)
-        item.change.is_merged = True
+
+        for i in [1, 2]:
+            try:
+                self.connection.mergePull(owner, project, pr_number, message,
+                                          sha)
+                item.change.is_merged = True
+                return
+            except MergeFailure:
+                self.log.debug(
+                    'Merge attempt of change %s  %s/2 failed.' %
+                    (i, item.change))
+                if i == 1:
+                    time.sleep(2)
+        self.log.debug(
+            'Merge of change %s failed after 2 attempts, giving up' %
+            item.change)
 
     def setLabels(self, item):
         owner, project = item.change.project.name.split('/')


### PR DESCRIPTION
This adds a comment to PRs when a successfully tested change fails
to merge into an upstream repository due to a Github API error. It
uses the merge_failure_message to format said message.

closes BonnyCI/projman#115

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>