### PR TITLE
Allow loading logging config from yaml

### DIFF
--- a/zuul/cmd/__init__.py
+++ b/zuul/cmd/__init__.py
@@ -24,6 +24,7 @@ import signal
 import sys
 import traceback
 
+import yaml
 yappi = extras.try_import('yappi')
 
 import zuul.lib.connections
@@ -86,7 +87,14 @@ class ZuulApp(object):
             if not os.path.exists(fp):
                 raise Exception("Unable to read logging config file at %s" %
                                 fp)
-            logging.config.fileConfig(fp)
+
+            if os.path.splitext(fp)[1] in ('.yml', '.yaml'):
+                with open(fp, 'r') as f:
+                    logging.config.dictConfig(yaml.safe_load(f))
+
+            else:
+                logging.config.fileConfig(fp)
+
         else:
             logging.basicConfig(level=logging.DEBUG)
 


### PR DESCRIPTION
The newer dictConfig logging configuration allows a much more flexible
configuration and should be used in preference to the file config. For
backwards compatibility if the logging configuration has a yaml
extension then load it, otherwise fall back to the file config.

Posted to OpenStack: https://review.openstack.org/436158

Change-Id: I755c785ad22c2d3b3e1e13784f2b2c8640211639
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>