### PR TITLE
Catch creator is None.

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -271,7 +271,11 @@ class GithubWebhookListener():
         seen = []
         statuses = []
         for status in self.connection.getCommitStatuses(owner, project, sha):
-            user = status.get('creator').get('login')
+            # creator can be None if the user has been removed.
+            creator = status.get('creator')
+            if not creator:
+                continue
+            user = creator.get('login')
             context = status.get('context')
             state = status.get('state')
             if "%s:%s" % (user, context) not in seen:


### PR DESCRIPTION
A weird scenario, if a status exists for a user that has been deleted
this will show as "ghost" on the github web ui and put null into the
json of delivered status events.

This happened when I was testing integrations and had recreated the
integration and bot user whilst the old status was still visible.

Change-Id: If5088ca6a4aa13f4946a0718576ce88f115b18e4
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>