### PR TITLE
Include exc_info in reporter failure

### DIFF
--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -119,7 +119,7 @@ class GithubReporter(BaseReporter):
             except MergeFailure:
                 self.log.debug(
                     'Merge attempt of change %s  %s/2 failed.' %
-                    (i, item.change))
+                    (i, item.change), exc_info=True)
                 if i == 1:
                     time.sleep(2)
         self.log.debug(


### PR DESCRIPTION
If a reporter fails to push up a status that's a bad and unusual
situation. Include the exception information in this log message so we
know exactly what went wrong and can hopefully fix it.

Change-Id: I309409350f84299b6761507a9c452a0617022339
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>