### PR TITLE
Fixup integrations to correctly use installation ids

### DIFF
--- a/doc/source/connections.rst
+++ b/doc/source/connections.rst
@@ -77,6 +77,11 @@ Create a connection with GitHub.
   Path to SSH key to use when cloning github repositories.
   ``sshkey=/home/zuul/.ssh/id_rsa``
 
+**git_host**
+  Optional: Hostname of the github install (such as a GitHub Enterprise)
+  If not specified, defaults to ``github.com``
+  ``git_host=github.myenterprise.com``
+
 SMTP
 ----
 

--- a/doc/source/connections.rst
+++ b/doc/source/connections.rst
@@ -73,6 +73,10 @@ Create a connection with GitHub.
   See `Securing your webhooks
   <https://developer.github.com/webhooks/securing/>`_.
 
+**sshkey**
+  Path to SSH key to use when cloning github repositories.
+  ``sshkey=/home/zuul/.ssh/id_rsa``
+
 SMTP
 ----
 

--- a/doc/source/connections.rst
+++ b/doc/source/connections.rst
@@ -55,6 +55,24 @@ want Zuul to gate.  For instance, you may want to grant ``Verified
 be added to Gerrit.  Zuul is very flexible and can take advantage of
 those.
 
+GitHub
+------
+
+Create a connection with GitHub.
+
+**driver=github**
+
+**api_token**
+  API token for accessing GitHub.
+  See `Creating an access token for command-line use
+  <https://help.github.com/articles/creating-an-access-token-for-command-line-use/>`_.
+
+**webhook_token**
+  Optional: Token for validating the webhook event payloads.
+  If not specified, payloads are not validated.
+  See `Securing your webhooks
+  <https://developer.github.com/webhooks/securing/>`_.
+
 SMTP
 ----
 

--- a/doc/source/reporters.rst
+++ b/doc/source/reporters.rst
@@ -28,6 +28,15 @@ with a value. For example, ``verified: 1`` becomes ``gerrit review
 A :ref:`connection` that uses the gerrit driver must be supplied to the
 trigger.
 
+GitHub
+------
+
+Zuul reports back to GitHub pull requests via GitHub API.
+It will create a comment containing the job status.
+
+A :ref:`connection` that uses the github driver must be supplied to the
+reporter. It has a string parameter, but it has no special meaning yet.
+
 SMTP
 ----
 

--- a/doc/source/reporters.rst
+++ b/doc/source/reporters.rst
@@ -55,6 +55,13 @@ reporter. It has the following options.
   merge the pull reqeust. Defaults to ``false``.
   ``merge=false``
 
+  **label**
+  List of strings each representing an exact label name which should be added
+  to the pull request by reporter. To remove a label by reporter prepend a dash
+  to the label name. Defaults to empty list.
+  ``label: 'test successful'``
+  ``label: '-test failed'``
+
 
 SMTP
 ----

--- a/doc/source/reporters.rst
+++ b/doc/source/reporters.rst
@@ -50,6 +50,11 @@ reporter. It has the following options.
   Defaults to ``false``.
   ``comment=true``
 
+  **merge**
+  Boolean value (``true`` or ``false``) that determines if the reporter should
+  merge the pull reqeust. Defaults to ``false``.
+  ``merge=false``
+
 
 SMTP
 ----

--- a/doc/source/reporters.rst
+++ b/doc/source/reporters.rst
@@ -32,10 +32,24 @@ GitHub
 ------
 
 Zuul reports back to GitHub pull requests via GitHub API.
-It will create a comment containing the job status.
+On success and failure, it creates a comment containing the build results.
+It also sets the status on start, success and failure. Status name and
+description is taken from the pipeline.
 
 A :ref:`connection` that uses the github driver must be supplied to the
-reporter. It has a string parameter, but it has no special meaning yet.
+reporter. It has the following options.
+
+  **status**
+  Boolean value (``true`` or ``false``) that determines if the reporter should
+  set commit status on github. Defaults to ``false``.
+  ``commit_status=true``
+
+  **comment**
+  Boolean value (``true`` or ``false``) that determines if the reporter should
+  add a comment with the pipeline status to the github pull request.
+  Defaults to ``false``.
+  ``comment=true``
+
 
 SMTP
 ----

--- a/doc/source/reporters.rst
+++ b/doc/source/reporters.rst
@@ -44,6 +44,10 @@ reporter. It has the following options.
   set commit status on github. Defaults to ``false``.
   ``commit_status=true``
 
+  **status_url**
+  String value for a link url to give to the github status. Defaults to the
+  zuul server status url, or the empty sting if that is unset.
+
   **comment**
   Boolean value (``true`` or ``false``) that determines if the reporter should
   add a comment with the pipeline status to the github pull request.

--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -120,6 +120,10 @@ following options.
 
     *pr-reopen* - pull request reopened
 
+    *push* - head reference updated (pushed to branch)
+
+    *tag* - new tag created
+
 
 GitHub Configuration
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -4,7 +4,7 @@ Triggers
 ========
 
 The process of merging a change starts with proposing a change to be
-merged.  Primarily, Zuul supports Gerrit as a triggering system.
+merged. Zuul supports Gerrit and GitHub as triggering systems.
 Zuul's design is modular, so alternate triggering and reporting
 systems can be supported.
 
@@ -99,6 +99,41 @@ the following options.
   This takes a list of approvals in the same format as
   *require-approval* but will fail to enter the pipeline if there is
   a matching approval.
+
+
+GitHub
+------
+
+Github webhook events can be configured as triggers.
+
+A connection name with the github driver can take multiple events with the
+following options.
+
+  **event**
+  Translated event from GitHub. Supported:
+
+    *pr-open* - pull request opened
+
+    *pr-change* - pull request synchronized
+
+    *pr-close* - pull request closed
+
+    *pr-reopen* - pull request reopened
+
+
+GitHub Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+Configure GitHub `webhook events
+<https://developer.github.com/webhooks/creating/>`_.
+
+Set *Payload URL* to
+``http://<zuul-hostname>/connection/<connection-name>/payload``.
+
+Set *Content Type* to ``application/json``.
+
+Select *Events* you are interested in. See above for the supported events.
+
 
 
 Timer

--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -122,6 +122,8 @@ following options.
 
     *pr-comment* - comment added on pull request
 
+    *pr-label* - label added or removed on pull request
+
     *push* - head reference updated (pushed to branch)
 
     *tag* - new tag created
@@ -133,6 +135,14 @@ following options.
   matched. ``comment: retrigger`` will match when comments
   containing 'retrigger' somewhere in the comment text are added to a
   pull request.
+
+  **label**
+  This is only used for ``pr-label`` events. It accepts a list of strings each
+  of which matches the label name in the event literally. Prepending a dash to
+  a label name means to match on that label removal.  ``label: recheck`` will
+  match when pull request is labeled with a ``recheck`` label. ``label: '-do
+  not test'`` will match when a label with name ``do not test`` is removed from
+  the pull request.
 
 
 GitHub Configuration

--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -128,6 +128,18 @@ following options.
 
     *tag* - new tag created
 
+  **branch**
+  The branch associated with the event. Example: ``master``.  This
+  field is treated as a regular expression, and multiple branches may
+  be listed. Used for ``pr-*`` events.
+
+  **ref**
+  Reference updated on ``push`` or ``tag`` event. This field is treated as a
+  regular expression and multiple refs may be listed. Github always sends full
+  ref name, eg. ``refs/tags/bar`` and this string is matched against the
+  regexp. Used for ``push`` and ``tag`` events.
+
+
   **comment**
   This is only used for ``pr-comment`` events.  It accepts a list of
   regexes that are searched for in the comment string. If any of these

--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -120,9 +120,19 @@ following options.
 
     *pr-reopen* - pull request reopened
 
+    *pr-comment* - comment added on pull request
+
     *push* - head reference updated (pushed to branch)
 
     *tag* - new tag created
+
+  **comment**
+  This is only used for ``pr-comment`` events.  It accepts a list of
+  regexes that are searched for in the comment string. If any of these
+  regexes matches a portion of the comment string the trigger is
+  matched. ``comment: retrigger`` will match when comments
+  containing 'retrigger' somewhere in the comment text are added to a
+  pull request.
 
 
 GitHub Configuration

--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -130,6 +130,8 @@ following options.
 
     *tag* - new tag created
 
+    *status* - status set on commit
+
   **branch**
   The branch associated with the event. Example: ``master``.  This
   field is treated as a regular expression, and multiple branches may
@@ -163,6 +165,11 @@ following options.
   each of which is matched to the review state, which can be one of
   ``approved``, ``comment``, or ``request_changes``.
 
+  **status**
+  This is only used for ``status`` events. It accepts a list of strings each of
+  which matches the user setting the status, the status context, and the status
+  itself in the format of ``user:context:status``.  For example,
+  ``zuul_github_ci_bot:check_pipeline:success``.
 
 GitHub Configuration
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/triggers.rst
+++ b/doc/source/triggers.rst
@@ -124,6 +124,8 @@ following options.
 
     *pr-label* - label added or removed on pull request
 
+    *pr-review* - review added on pull request
+
     *push* - head reference updated (pushed to branch)
 
     *tag* - new tag created
@@ -155,6 +157,11 @@ following options.
   match when pull request is labeled with a ``recheck`` label. ``label: '-do
   not test'`` will match when a label with name ``do not test`` is removed from
   the pull request.
+
+  **state**
+  This is only used for ``pr-review`` events.  It accepts a list of strings
+  each of which is matched to the review state, which can be one of
+  ``approved``, ``comment``, or ``request_changes``.
 
 
 GitHub Configuration

--- a/doc/source/zuul.rst
+++ b/doc/source/zuul.rst
@@ -455,6 +455,19 @@ explanation of each of the parameters::
     be a single value or a list: ``verified: [1, 2]`` would match
     either a +1 or +2 vote.
 
+    A note on GitHub; GitHub supports pull-request reviews. These
+    can be provided by anybody with read access to a repository. A
+    review may approve, request changes, or simply comment on the
+    change. Within Zuul these reviews are mapped to appear like an
+    approval. An ``approve`` or ``request_changes`` review is mapped
+    to a category of ``review``, whereas a ``comment`` review is
+    mapped to a category of ``comment``. If a reviewer has write
+    access to the repository in question, their review is given a
+    value of ``2`` or ``-2`` for ``approve`` or ``request_changes``
+    respectfully. Reviewers with only read access are assigned a
+    value of ``1`` or ``-1``. All ``comment`` reviews are given a
+    value of ``0``.
+
   **open**
   A boolean value (``true`` or ``false``) that indicates whether the change
   must be open or closed in order to be enqueued.

--- a/etc/status/public_html/jquery.zuul.js
+++ b/etc/status/public_html/jquery.zuul.js
@@ -52,6 +52,10 @@
 
         var collapsed_exceptions = [];
         var current_filter = read_cookie('zuul_filter_string', '');
+        var change_set_in_url = window.location.href.split('#')[1];
+        if (change_set_in_url) {
+           current_filter = change_set_in_url;
+        }
         var $jq;
 
         var xhr,

--- a/etc/status/public_html/jquery.zuul.js
+++ b/etc/status/public_html/jquery.zuul.js
@@ -275,7 +275,16 @@
 
                 var $change_link = $('<small />');
                 if (change.url !== null) {
-                    if (/^[0-9a-f]{40}$/.test(change.id)) {
+                    var github_id = change.id.match(/^([0-9]+),([0-9a-f]{40})$/);
+                    if (github_id) {
+                        $change_link.append(
+                            $('<a />').attr('href', change.url).append(
+                                $('<abbr />')
+                                    .attr('title', change.id)
+                                    .text('#' + github_id[1])
+                            )
+                        );
+                    } else if (/^[0-9a-f]{40}$/.test(change.id)) {
                         var change_id_short = change.id.slice(0, 7);
                         $change_link.append(
                             $('<a />').attr('href', change.url).append(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 pbr>=1.1.0
 
+Github3.py
 PyYAML>=3.1.0
-Paste
+Paste<2.0
 WebOb>=1.2.3
 paramiko>=1.8.0,<2.0.0
 GitPython>=0.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pbr>=1.1.0
 
-Github3.py
+Github3.py==1.0.0a2
 PyYAML>=3.1.0
 Paste<2.0
 WebOb>=1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ apscheduler>=3.0
 PrettyTable>=0.6,<0.8
 babel>=1.0
 six>=1.6.0
+pyjwt
+cryptography
+iso8601

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 pbr>=1.1.0
 
-Github3.py==1.0.0a2
+# pull from master until https://github.com/sigmavirus24/github3.py/pull/671
+# is in a release
+-e git://github.com/sigmavirus24/github3.py.git@develop#egg=Github3.py
 PyYAML>=3.1.0
 Paste<2.0
 WebOb>=1.2.3

--- a/tests/base.py
+++ b/tests/base.py
@@ -678,6 +678,9 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
     def getGitUrl(self, project):
         return os.path.join(self.upstream_root, str(project))
 
+    def real_getGitUrl(self, project):
+        return super(FakeGithubConnection, self).getGitUrl(project)
+
     def report(self, owner, project, pr_number, message, params=None):
         pull_request = self.pull_requests[pr_number - 1]
         pull_request.addComment(message)

--- a/tests/base.py
+++ b/tests/base.py
@@ -666,10 +666,9 @@ class FakeGithubPullRequest(object):
         repo = self._getRepo()
         return repo.references[self._getPRReference()].commit.hexsha
 
-    def setStatus(self, sha, state, url, description, context):
+    def setStatus(self, sha, state, url, description, context, user='zuul'):
         # Since we're bypassing github API, which would require a user, we
         # hard set the user as 'zuul' here.
-        user = 'zuul'
         # insert the status at the top of the list, to simulate that it
         # is the most recent set status
         self.statuses[sha].insert(0, ({
@@ -709,6 +708,21 @@ class FakeGithubPullRequest(object):
             },
             'sender': {
                 'login': 'ghuser'
+            }
+        }
+        return (name, data)
+
+    def getCommitStatusEvent(self, context, state='success', user='zuul'):
+        name = 'status'
+        data = {
+            'state': state,
+            'sha': self.head_sha,
+            'description': 'Test results for %s: %s' % (self.head_sha, state),
+            'target_url': 'http://zuul/%s' % self.head_sha,
+            'branches': [],
+            'context': context,
+            'sender': {
+                'login': user
             }
         }
         return (name, data)
@@ -797,6 +811,14 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
             }
         }
         return data
+
+    def getPullBySha(self, sha):
+        prs = list(set([p for p in self.pull_requests if sha == p.head_sha]))
+        if len(prs) > 1:
+            raise Exception('Multiple pulls found with head sha: %s' % sha)
+        pr = prs[0]
+        owner, project = pr.project.split('/')
+        return self.getPull(owner, project, pr.number)
 
     def getPullFileNames(self, owner, project, number):
         pr = self.pull_requests[number - 1]

--- a/tests/base.py
+++ b/tests/base.py
@@ -1371,7 +1371,6 @@ class ZuulTestCase(BaseTestCase):
         # Set a changes database so multiple FakeGerrit's can report back to
         # a virtual canonical database given by the configured hostname
         self.gerrit_changes_dbs = {}
-        self.gerrit_queues_dbs = {}
         self.connections = {}
 
         for section_name in self.config.sections():
@@ -1392,15 +1391,12 @@ class ZuulTestCase(BaseTestCase):
             if con_driver == 'gerrit':
                 if con_config['server'] not in self.gerrit_changes_dbs.keys():
                     self.gerrit_changes_dbs[con_config['server']] = {}
-                if con_config['server'] not in self.gerrit_queues_dbs.keys():
-                    self.gerrit_queues_dbs[con_config['server']] = \
-                        Queue.Queue()
-                    self.event_queues.append(
-                        self.gerrit_queues_dbs[con_config['server']])
+                queues_db = Queue.Queue()
+                self.event_queues.append(queues_db)
                 self.connections[con_name] = FakeGerritConnection(
                     con_name, con_config,
                     changes_db=self.gerrit_changes_dbs[con_config['server']],
-                    queues_db=self.gerrit_queues_dbs[con_config['server']],
+                    queues_db=queues_db,
                     upstream_root=self.upstream_root
                 )
                 setattr(self, 'fake_' + con_name, self.connections[con_name])
@@ -1420,12 +1416,12 @@ class ZuulTestCase(BaseTestCase):
 
         if 'gerrit' in self.config.sections():
             self.gerrit_changes_dbs['gerrit'] = {}
-            self.gerrit_queues_dbs['gerrit'] = Queue.Queue()
-            self.event_queues.append(self.gerrit_queues_dbs['gerrit'])
+            queues_db = Queue.Queue()
+            self.event_queues.append(queues_db)
             self.connections['gerrit'] = FakeGerritConnection(
                 '_legacy_gerrit', dict(self.config.items('gerrit')),
                 changes_db=self.gerrit_changes_dbs['gerrit'],
-                queues_db=self.gerrit_queues_dbs['gerrit'])
+                queues_db=queues_db)
 
         if 'smtp' in self.config.sections():
             self.connections['smtp'] = \

--- a/tests/base.py
+++ b/tests/base.py
@@ -43,6 +43,7 @@ import testtools
 from git import GitCommandError
 
 import zuul.connection.gerrit
+import zuul.connection.github
 import zuul.connection.smtp
 import zuul.scheduler
 import zuul.webapp
@@ -55,7 +56,9 @@ import zuul.merger.server
 import zuul.reporter.gerrit
 import zuul.reporter.smtp
 import zuul.source.gerrit
+import zuul.source.github
 import zuul.trigger.gerrit
+import zuul.trigger.github
 import zuul.trigger.timer
 import zuul.trigger.zuultrigger
 
@@ -93,12 +96,12 @@ def iterate_timeout(max_seconds, purpose):
     raise Exception("Timeout waiting for %s" % purpose)
 
 
-class ChangeReference(git.Reference):
+class GerritChangeReference(git.Reference):
     _common_path_default = "refs/changes"
     _points_to_commits_only = True
 
 
-class FakeChange(object):
+class FakeGerritChange(object):
     categories = {'APRV': ('Approved', -1, 1),
                   'CRVW': ('Code-Review', -2, 2),
                   'VRFY': ('Verified', -2, 2)}
@@ -145,9 +148,9 @@ class FakeChange(object):
     def add_fake_change_to_repo(self, msg, fn, large):
         path = os.path.join(self.upstream_root, self.project)
         repo = git.Repo(path)
-        ref = ChangeReference.create(repo, '1/%s/%s' % (self.number,
-                                                        self.latest_patchset),
-                                     'refs/tags/init')
+        ref = GerritChangeReference.create(
+            repo, '1/%s/%s' % (self.number, self.latest_patchset),
+            'refs/tags/init')
         repo.head.reference = ref
         zuul.merger.merger.reset_repo_to_head(repo)
         repo.git.clean('-x', '-f', '-d')
@@ -398,9 +401,9 @@ class FakeGerritConnection(zuul.connection.gerrit.GerritConnection):
 
     def addFakeChange(self, project, branch, subject, status='NEW'):
         self.change_number += 1
-        c = FakeChange(self, self.change_number, project, branch, subject,
-                       upstream_root=self.upstream_root,
-                       status=status)
+        c = FakeGerritChange(self, self.change_number, project, branch,
+                             subject, upstream_root=self.upstream_root,
+                             status=status)
         self.changes[self.change_number] = c
         return c
 
@@ -462,6 +465,154 @@ class FakeGerritConnection(zuul.connection.gerrit.GerritConnection):
 
     def getGitUrl(self, project):
         return os.path.join(self.upstream_root, project.name)
+
+
+class GithubChangeReference(git.Reference):
+    _common_path_default = "refs/pull"
+    _points_to_commits_only = True
+
+
+class FakeGithubPullRequest(object):
+
+    def __init__(self, github, number, project, branch,
+                 upstream_root, number_of_commits=1):
+        """Creates a new PR with several commits.
+        Sends an event about opened PR."""
+        self.github = github
+        self.number = number
+        self.project = project
+        self.branch = branch
+        self.upstream_root = upstream_root
+        self.comments = []
+        self.updated_at = None
+        self.head_sha = None
+        self._createPRRef()
+        self._addCommitToRepo()
+        self._updateTimeStamp()
+
+    def addCommit(self):
+        """Adds a commit on top of the actual PR head."""
+        self._addCommitToRepo()
+        self._updateTimeStamp()
+
+    def forcePush(self):
+        """Clears actual commits and add a commit on top of the base."""
+        self._addCommitToRepo(reset=True)
+        self._updateTimeStamp()
+
+    def getPullRequestOpenedEvent(self):
+        return self._getPullRequestEvent('opened')
+
+    def getPullRequestSynchronizeEvent(self):
+        return self._getPullRequestEvent('synchronize')
+
+    def getPullRequestReopenedEvent(self):
+        return self._getPullRequestEvent('reopened')
+
+    def getPullRequestClosedEvent(self):
+        return self._getPullRequestEvent('closed')
+
+    def addComment(self, message):
+        self.comments.append(message)
+        self._updateTimeStamp()
+
+    def _getRepo(self):
+        repo_path = os.path.join(self.upstream_root, self.project)
+        return git.Repo(repo_path)
+
+    def _createPRRef(self):
+        repo = self._getRepo()
+        GithubChangeReference.create(
+            repo, self._getPRReference(), 'refs/tags/init')
+
+    def _addCommitToRepo(self, reset=False):
+        repo = self._getRepo()
+        ref = repo.references[self._getPRReference()]
+        if reset:
+            ref.set_object('refs/tags/init')
+        repo.head.reference = ref
+        zuul.merger.merger.reset_repo_to_head(repo)
+        repo.git.clean('-x', '-f', '-d')
+
+        fn = '%s-%s' % (self.branch.replace('/', '_'), self.number)
+        msg = 'test-%s' % self.number
+        fn = os.path.join(repo.working_dir, fn)
+        f = open(fn, 'w')
+        with open(fn, 'w') as f:
+            f.write("test %s %s\n" %
+                    (self.branch, self.number))
+        repo.index.add([fn])
+
+        self.head_sha = repo.index.commit(msg).hexsha
+        repo.head.reference = 'master'
+        zuul.merger.merger.reset_repo_to_head(repo)
+        repo.git.clean('-x', '-f', '-d')
+        repo.heads['master'].checkout()
+
+    def _updateTimeStamp(self):
+        self.updated_at = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.localtime())
+
+    def getPRHeadSha(self):
+        repo = self._getRepo()
+        return repo.references[self._getPRReference()].commit.hexsha
+
+    def _getPRReference(self):
+        return '%s/head' % self.number
+
+    def _getPullRequestEvent(self, action):
+        name = 'pull_request'
+        data = {
+            'action': action,
+            'number': self.number,
+            'pull_request': {
+                'number': self.number,
+                'updated_at': self.updated_at,
+                'base': {
+                    'ref': self.branch,
+                    'repo': {
+                        'full_name': self.project
+                    }
+                },
+                'head': {
+                    'sha': self.head_sha
+                }
+            }
+        }
+        return (name, data)
+
+
+class FakeGithubConnection(zuul.connection.github.GithubConnection):
+    log = logging.getLogger("zuul.test.FakeGithubConnection")
+
+    def __init__(self, connection_name, connection_config, upstream_root=None):
+        super(FakeGithubConnection, self).__init__(connection_name,
+                                                   connection_config)
+        self.connection_name = connection_name
+        self.pr_number = 0
+        self.pull_requests = []
+        self.upstream_root = upstream_root
+
+    def openFakePullRequest(self, project, branch):
+        self.pr_number += 1
+        pull_request = FakeGithubPullRequest(
+            self, self.pr_number, project, branch, self.upstream_root)
+        self.pull_requests.append(pull_request)
+        return pull_request
+
+    def emitEvent(self, event):
+        """Emulates sending the GitHub webhook event to the connection."""
+        port = self.webapp.server.socket.getsockname()[1]
+        name, data = event
+        payload = json.dumps(data)
+        headers = {'X-Github-Event': name}
+        req = urllib.request.Request(
+            'http://localhost:%s/connection/%s/payload'
+            % (port, self.connection_name),
+            data=payload, headers=headers)
+        urllib.request.urlopen(req)
+
+    def getGitUrl(self, project):
+        return os.path.join(self.upstream_root, str(project))
 
 
 class BuildHistory(object):
@@ -1064,6 +1215,10 @@ class ZuulTestCase(BaseTestCase):
                     queues_db=self.gerrit_queues_dbs[con_config['server']],
                     upstream_root=self.upstream_root
                 )
+                setattr(self, 'fake_' + con_name, self.connections[con_name])
+            elif con_driver == 'github':
+                self.connections[con_name] = FakeGithubConnection(
+                    con_name, con_config, upstream_root=self.upstream_root)
                 setattr(self, 'fake_' + con_name, self.connections[con_name])
             elif con_driver == 'smtp':
                 self.connections[con_name] = \

--- a/tests/base.py
+++ b/tests/base.py
@@ -486,6 +486,7 @@ class FakeGithubPullRequest(object):
         self.branch = branch
         self.upstream_root = upstream_root
         self.comments = []
+        self.labels = []
         self.statuses = {}
         self.updated_at = None
         self.head_sha = None
@@ -534,6 +535,41 @@ class FakeGithubPullRequest(object):
             },
             'repository': {
                 'full_name': self.project
+            }
+        }
+        return (name, data)
+
+    def addLabel(self, name):
+        if name not in self.labels:
+            self.labels.append(name)
+            self._updateTimeStamp()
+            return self._getLabelEvent(name, 'labeled')
+
+    def removeLabel(self, name):
+        if name in self.labels:
+            self.labels.remove(name)
+            self._updateTimeStamp()
+            return self._getLabelEvent(name, 'unlabeled')
+
+    def _getLabelEvent(self, label, action):
+        name = 'pull_request'
+        data = {
+            'action': action,
+            'pull_request': {
+                'number': self.number,
+                'updated_at': self.updated_at,
+                'base': {
+                    'ref': self.branch,
+                    'repo': {
+                        'full_name': self.project
+                    }
+                },
+                'head': {
+                    'sha': self.head_sha
+                }
+            },
+            'label': {
+                'name': label
             }
         }
         return (name, data)
@@ -719,6 +755,14 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
             if (pr_owner == owner and pr_project == project and
                 pr.head_sha == sha):
                 pr.setStatus(state, url, description, context)
+
+    def labelPull(self, owner, project, pr_number, label):
+        pull_request = self.pull_requests[pr_number - 1]
+        pull_request.addLabel(label)
+
+    def unlabelPull(self, owner, project, pr_number, label):
+        pull_request = self.pull_requests[pr_number - 1]
+        pull_request.removeLabel(label)
 
 
 class BuildHistory(object):

--- a/tests/base.py
+++ b/tests/base.py
@@ -973,6 +973,8 @@ class ZuulTestCase(BaseTestCase):
         self.useFixture(fixtures.MonkeyPatch('swiftclient.client.Connection',
                                              FakeSwiftClientConnection))
         self.swift = zuul.lib.swift.Swift(self.config)
+        self.webapp = zuul.webapp.WebApp(
+            self.sched, port=0, listen_address='127.0.0.1')
 
         self.event_queues = [
             self.sched.result_event_queue,
@@ -980,7 +982,7 @@ class ZuulTestCase(BaseTestCase):
         ]
 
         self.configure_connections()
-        self.sched.registerConnections(self.connections)
+        self.sched.registerConnections(self.connections, self.webapp)
 
         def URLOpenerFactory(*args, **kw):
             if isinstance(args[0], urllib.request.Request):
@@ -1002,8 +1004,6 @@ class ZuulTestCase(BaseTestCase):
         self.sched.setLauncher(self.launcher)
         self.sched.setMerger(self.merge_client)
 
-        self.webapp = zuul.webapp.WebApp(
-            self.sched, port=0, listen_address='127.0.0.1')
         self.rpc = zuul.rpclistener.RPCListener(self.config, self.sched)
 
         self.sched.start()

--- a/tests/base.py
+++ b/tests/base.py
@@ -546,6 +546,36 @@ class FakeGithubPullRequest(object):
         }
         return (name, data)
 
+    def getReviewAddedEvent(self, review):
+        name = 'pull_request_review'
+        data = {
+            'action': 'submitted',
+            'pull_request': {
+                'number': self.number,
+                'title': self.subject,
+                'updated_at': self.updated_at,
+                'base': {
+                    'ref': self.branch,
+                    'repo': {
+                        'full_name': self.project
+                    }
+                },
+                'head': {
+                    'sha': self.head_sha
+                }
+            },
+            'review': {
+                'state': review
+            },
+            'repository': {
+                'full_name': self.project
+            },
+            'sender': {
+                'login': 'ghuser'
+            }
+        }
+        return (name, data)
+
     def addLabel(self, name):
         if name not in self.labels:
             self.labels.append(name)

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,6 +15,7 @@
 # under the License.
 
 from six.moves import configparser as ConfigParser
+import datetime
 import gc
 import hashlib
 import json
@@ -685,21 +686,37 @@ class FakeGithubPullRequest(object):
         }))
 
     def addReview(self, user, state, granted_on=None):
-        # Each user will only have one review at a time, so replace
-        # any existing reviews
-        for review in self.reviews:
-            if review['user']['login'] == user:
-                self.reviews.remove(review)
+        gh_time_format = '%Y-%m-%dT%H:%M:%SZ'
+        # convert the timestamp to a str format that would be returned
+        # from github as 'submitted_at' in the API response
 
-        if not granted_on:
-            granted_on = time.time()
+        if granted_on:
+            granted_on = datetime.datetime.utcfromtimestamp(granted_on)
+            submitted_at = time.strftime(
+                gh_time_format, granted_on.timetuple())
+        else:
+            # github timestamps only down to the second, so we need to make
+            # sure reviews that tests add appear to be added over a period of
+            # time in the past and not all at once.
+            if not self.reviews:
+                # the first review happens 10 mins ago
+                offset = 600
+            else:
+                # subsequent reviews happen 1 minute closer to now
+                offset = 600 - (len(self.reviews) * 60)
+
+            granted_on = datetime.datetime.utcfromtimestamp(
+                time.time() - offset)
+            submitted_at = time.strftime(
+                gh_time_format, granted_on.timetuple())
+
         self.reviews.append({
             'state': state,
             'user': {
                 'login': user,
                 'email': user + "@derp.com",
             },
-            'provided': int(granted_on),
+            'submitted_at': submitted_at,
         })
 
     def _getPRReference(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -54,6 +54,7 @@ import zuul.merger.client
 import zuul.merger.merger
 import zuul.merger.server
 import zuul.reporter.gerrit
+import zuul.reporter.github
 import zuul.reporter.smtp
 import zuul.source.gerrit
 import zuul.source.github
@@ -613,6 +614,10 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
 
     def getGitUrl(self, project):
         return os.path.join(self.upstream_root, str(project))
+
+    def report(self, owner, project, pr_number, message, params=None):
+        pull_request = self.pull_requests[pr_number - 1]
+        pull_request.addComment(message)
 
 
 class BuildHistory(object):

--- a/tests/base.py
+++ b/tests/base.py
@@ -503,13 +503,11 @@ class FakeGithubPullRequest(object):
         """Adds a commit on top of the actual PR head."""
         self._addCommitToRepo(files=files)
         self._updateTimeStamp()
-        self._clearStatuses()
 
     def forcePush(self, files=[]):
         """Clears actual commits and add a commit on top of the base."""
         self._addCommitToRepo(files=files, reset=True)
         self._updateTimeStamp()
-        self._clearStatuses()
 
     def getPullRequestOpenedEvent(self):
         return self._getPullRequestEvent('opened')
@@ -573,7 +571,10 @@ class FakeGithubPullRequest(object):
                     }
                 },
                 'head': {
-                    'sha': self.head_sha
+                    'sha': self.head_sha,
+                    'repo': {
+                        'full_name': self.project
+                    }
                 }
             },
             'label': {
@@ -620,6 +621,9 @@ class FakeGithubPullRequest(object):
         repo.index.add([fn])
 
         self.head_sha = repo.index.commit(msg).hexsha
+        # Create an empty set of statuses for the given sha,
+        # each sha on a PR may have a status set on it
+        self.statuses[self.head_sha] = []
         repo.head.reference = 'master'
         zuul.merger.merger.reset_repo_to_head(repo)
         repo.git.clean('-x', '-f', '-d')
@@ -632,15 +636,21 @@ class FakeGithubPullRequest(object):
         repo = self._getRepo()
         return repo.references[self._getPRReference()].commit.hexsha
 
-    def setStatus(self, state, url, description, context):
-        self.statuses[context] = {
+    def setStatus(self, sha, state, url, description, context):
+        # Since we're bypassing github API, which would require a user, we
+        # hard set the user as 'zuul' here.
+        user = 'zuul'
+        # insert the status at the top of the list, to simulate that it
+        # is the most recent set status
+        self.statuses[sha].insert(0, ({
             'state': state,
             'url': url,
-            'description': description
-        }
-
-    def _clearStatuses(self):
-        self.statuses = {}
+            'description': description,
+            'context': context,
+            'creator': {
+                'login': user
+            }
+        }))
 
     def _getPRReference(self):
         return '%s/head' % self.number
@@ -661,7 +671,10 @@ class FakeGithubPullRequest(object):
                     }
                 },
                 'head': {
-                    'sha': self.head_sha
+                    'sha': self.head_sha,
+                    'repo': {
+                        'full_name': self.project
+                    }
                 }
             },
             'sender': {
@@ -747,7 +760,10 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
                 'ref': pr.branch,
             },
             'head': {
-                'sha': pr.head_sha
+                'sha': pr.head_sha,
+                'repo': {
+                    'full_name': pr.project
+                }
             }
         }
         return data
@@ -786,13 +802,20 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         pull_request.is_merged = True
         pull_request.merge_message = commit_message
 
+    def getCommitStatuses(self, owner, project, sha):
+        for pr in self.pull_requests:
+            pr_owner, pr_project = pr.project.split('/')
+            if (pr_owner == owner and pr_project == project and
+                pr.head_sha == sha):
+                return pr.statuses[sha]
+
     def setCommitStatus(self, owner, project, sha, state,
                         url='', description='', context=''):
         for pr in self.pull_requests:
             pr_owner, pr_project = pr.project.split('/')
             if (pr_owner == owner and pr_project == project and
                 pr.head_sha == sha):
-                pr.setStatus(state, url, description, context)
+                pr.setStatus(sha, state, url, description, context)
 
     def labelPull(self, owner, project, pr_number, label):
         pull_request = self.pull_requests[pr_number - 1]

--- a/tests/base.py
+++ b/tests/base.py
@@ -477,7 +477,8 @@ class GithubChangeReference(git.Reference):
 class FakeGithubPullRequest(object):
 
     def __init__(self, github, number, project, branch,
-                 subject, upstream_root, files=[], number_of_commits=1):
+                 subject, upstream_root, files=[], number_of_commits=1,
+                 writers=[]):
         """Creates a new PR with several commits.
         Sends an event about opened PR."""
         self.github = github
@@ -491,6 +492,8 @@ class FakeGithubPullRequest(object):
         self.comments = []
         self.labels = []
         self.statuses = {}
+        self.reviews = []
+        self.writers = []
         self.updated_at = None
         self.head_sha = None
         self.is_merged = False
@@ -681,6 +684,24 @@ class FakeGithubPullRequest(object):
             }
         }))
 
+    def addReview(self, user, state, granted_on=None):
+        # Each user will only have one review at a time, so replace
+        # any existing reviews
+        for review in self.reviews:
+            if review['user']['login'] == user:
+                self.reviews.remove(review)
+
+        if not granted_on:
+            granted_on = time.time()
+        self.reviews.append({
+            'state': state,
+            'user': {
+                'login': user,
+                'email': user + "@derp.com",
+            },
+            'provided': int(granted_on),
+        })
+
     def _getPRReference(self):
         return '%s/head' % self.number
 
@@ -824,6 +845,10 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         pr = self.pull_requests[number - 1]
         return pr.files
 
+    def getPullReviews(self, owner, project, number):
+        pr = self.pull_requests[number - 1]
+        return pr.reviews
+
     def getUser(self, login):
         data = {
             'username': login,
@@ -831,6 +856,15 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
             'email': 'github.user@example.com'
         }
         return data
+
+    def getRepoPermission(self, owner, project, login):
+        for pr in self.pull_requests:
+            pr_owner, pr_project = pr.project.split('/')
+            if (pr_owner == owner and pr_project):
+                if login in pr.writers:
+                    return 'write'
+                else:
+                    return 'read'
 
     def getGitUrl(self, project):
         return os.path.join(self.upstream_root, str(project))

--- a/tests/base.py
+++ b/tests/base.py
@@ -477,13 +477,15 @@ class GithubChangeReference(git.Reference):
 class FakeGithubPullRequest(object):
 
     def __init__(self, github, number, project, branch,
-                 upstream_root, number_of_commits=1):
+                 subject, upstream_root, number_of_commits=1):
         """Creates a new PR with several commits.
         Sends an event about opened PR."""
         self.github = github
         self.number = number
         self.project = project
         self.branch = branch
+        self.subject = subject
+        self.number_of_commits = 0
         self.upstream_root = upstream_root
         self.comments = []
         self.labels = []
@@ -587,13 +589,15 @@ class FakeGithubPullRequest(object):
         repo = self._getRepo()
         ref = repo.references[self._getPRReference()]
         if reset:
+            self.number_of_commits = 0
             ref.set_object('refs/tags/init')
+        self.number_of_commits += 1
         repo.head.reference = ref
         zuul.merger.merger.reset_repo_to_head(repo)
         repo.git.clean('-x', '-f', '-d')
 
         fn = '%s-%s' % (self.branch.replace('/', '_'), self.number)
-        msg = 'test-%s' % self.number
+        msg = self.subject + '-' + str(self.number_of_commits)
         fn = os.path.join(repo.working_dir, fn)
         f = open(fn, 'w')
         with open(fn, 'w') as f:
@@ -662,10 +666,10 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         self.merge_failure = False
         self.merge_not_allowed_count = 0
 
-    def openFakePullRequest(self, project, branch):
+    def openFakePullRequest(self, project, branch, subject):
         self.pr_number += 1
         pull_request = FakeGithubPullRequest(
-            self, self.pr_number, project, branch, self.upstream_root)
+            self, self.pr_number, project, branch, subject, self.upstream_root)
         self.pull_requests.append(pull_request)
         return pull_request
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -600,6 +600,36 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         self.pull_requests.append(pull_request)
         return pull_request
 
+    def getTagEvent(self, project, tag, sha=None):
+        if not sha:
+            sha = random_sha1()
+        event_name = 'push'
+        event_data = {
+            'ref': 'refs/tags/%s' % tag,
+            'before': '00000000000000000000000000000000',
+            'after': sha,
+            'repository': {
+                'full_name': project
+            }
+        }
+        return (event_name, event_data)
+
+    def getPushEvent(self, project, branch, old_rev=None, new_rev=None):
+        if not old_rev:
+            old_rev = random_sha1()
+        if not new_rev:
+            new_rev = random_sha1()
+        name = 'push'
+        data = {
+            'ref': 'refs/heads/%s' % branch,
+            'before': old_rev,
+            'after': new_rev,
+            'repository': {
+                'full_name': project
+            }
+        }
+        return (name, data)
+
     def emitEvent(self, event):
         """Emulates sending the GitHub webhook event to the connection."""
         port = self.webapp.server.socket.getsockname()[1]

--- a/tests/base.py
+++ b/tests/base.py
@@ -517,6 +517,22 @@ class FakeGithubPullRequest(object):
         self.comments.append(message)
         self._updateTimeStamp()
 
+    def getCommentAddedEvent(self, text):
+        name = 'issue_comment'
+        data = {
+            'action': 'created',
+            'issue': {
+                'number': self.number
+            },
+            'comment': {
+                'body': text
+            },
+            'repository': {
+                'full_name': self.project
+            }
+        }
+        return (name, data)
+
     def _getRepo(self):
         repo_path = os.path.join(self.upstream_root, self.project)
         return git.Repo(repo_path)
@@ -641,6 +657,23 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
             % (port, self.connection_name),
             data=payload, headers=headers)
         urllib.request.urlopen(req)
+
+    def getPull(self, owner, project, number):
+        pr = self.pull_requests[number - 1]
+        data = {
+            'number': number,
+            'updated_at': pr.updated_at,
+            'base': {
+                'repo': {
+                    'full_name': pr.project
+                },
+                'ref': pr.branch,
+            },
+            'head': {
+                'sha': pr.head_sha
+            }
+        }
+        return data
 
     def getGitUrl(self, project):
         return os.path.join(self.upstream_root, str(project))

--- a/tests/fixtures/layout-connections-gerrit-and-github.yaml
+++ b/tests/fixtures/layout-connections-gerrit-and-github.yaml
@@ -1,0 +1,38 @@
+pipelines:
+  - name: check_github
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event:
+            - pr-open
+            - pr-change
+            - pr-reopen
+    success:
+      github:
+        status: true
+    failure:
+      github:
+        status: true
+
+  - name: check_gerrit
+    manager: IndependentPipelineManager
+    source: gerrit
+    trigger:
+      gerrit:
+        - event: patchset-created
+    success:
+      gerrit:
+        VRFY: 1
+    failure:
+      gerrit:
+        VRFY: -1
+
+projects:
+  - name: org/project
+    check_gerrit:
+      - project-gerrit
+
+  - name: org/project1
+    check_github:
+      - project1-github

--- a/tests/fixtures/layout-github-requirement-newer-than.yaml
+++ b/tests/fixtures/layout-github-requirement-newer-than.yaml
@@ -1,0 +1,37 @@
+pipelines:
+  - name: newer_than
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - review: 2
+          newer-than: 1d
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+  - name: older_than
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - review: 2
+          older-than: 1d
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+projects:
+  - name: org/project1
+    newer_than:
+      - project1-pipeline
+  - name: org/project2
+    older_than:
+      - project2-pipeline

--- a/tests/fixtures/layout-github-requirement-state.yaml
+++ b/tests/fixtures/layout-github-requirement-state.yaml
@@ -1,0 +1,37 @@
+pipelines:
+  - name: pipeline
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - review: 2
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+#  - name: trigger
+#    manager: IndependentPipelineManager
+#    trigger:
+#      github:
+#        - event: pr-comment
+#          comment: 'test me'
+#          require-approval:
+#            - username: zuul
+#    success:
+#      github:
+#        comment: true
+#    failure:
+#      github:
+#        status: true
+
+projects:
+  - name: org/project1
+    pipeline:
+      - project1-pipeline
+#  - name: org/project2
+#    trigger:
+#      - project2-trigger

--- a/tests/fixtures/layout-github-requirement-state.yaml
+++ b/tests/fixtures/layout-github-requirement-state.yaml
@@ -5,6 +5,9 @@ pipelines:
     require:
       approval:
         - review: 2
+    reject:
+      approval:
+        - review: -2
     trigger:
       github:
         - event: pr-comment

--- a/tests/fixtures/layout-github-requirement-status.yaml
+++ b/tests/fixtures/layout-github-requirement-status.yaml
@@ -1,0 +1,36 @@
+pipelines:
+  - name: pipeline
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      status: "zuul:check:success"
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+#  - name: trigger
+#    manager: IndependentPipelineManager
+#    trigger:
+#      github:
+#        - event: pr-comment
+#          comment: 'test me'
+#          require-approval:
+#            - username: zuul
+#    success:
+#      github:
+#        comment: true
+#    failure:
+#      github:
+#        status: true
+
+projects:
+  - name: org/project1
+    pipeline:
+      - project1-pipeline
+#  - name: org/project2
+#    trigger:
+#      - project2-trigger

--- a/tests/fixtures/layout-github-requirement-status.yaml
+++ b/tests/fixtures/layout-github-requirement-status.yaml
@@ -12,25 +12,24 @@ pipelines:
       github:
         comment: true
 
-#  - name: trigger
-#    manager: IndependentPipelineManager
-#    trigger:
-#      github:
-#        - event: pr-comment
-#          comment: 'test me'
-#          require-approval:
-#            - username: zuul
-#    success:
-#      github:
-#        comment: true
-#    failure:
-#      github:
-#        status: true
+  - name: trigger
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: status
+          status: 'zuul:check:success'
+    success:
+      github:
+        comment: true
+    failure:
+      github:
+        status: true
 
 projects:
   - name: org/project1
     pipeline:
       - project1-pipeline
-#  - name: org/project2
-#    trigger:
-#      - project2-trigger
+  - name: org/project2
+    trigger:
+      - project2-trigger

--- a/tests/fixtures/layout-github-requirement-username-state.yaml
+++ b/tests/fixtures/layout-github-requirement-username-state.yaml
@@ -1,0 +1,38 @@
+pipelines:
+  - name: pipeline
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - username: derp
+          review: 2
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+#  - name: trigger
+#    manager: IndependentPipelineManager
+#    trigger:
+#      github:
+#        - event: pr-comment
+#          comment: 'test me'
+#          require-approval:
+#            - username: zuul
+#    success:
+#      github:
+#        comment: true
+#    failure:
+#      github:
+#        status: true
+
+projects:
+  - name: org/project1
+    pipeline:
+      - project1-pipeline
+#  - name: org/project2
+#    trigger:
+#      - project2-trigger

--- a/tests/fixtures/layout-github-requirement-username-state.yaml
+++ b/tests/fixtures/layout-github-requirement-username-state.yaml
@@ -6,6 +6,9 @@ pipelines:
       approval:
         - username: derp
           review: 2
+    reject:
+       approval:
+         - review: -2
     trigger:
       github:
         - event: pr-comment

--- a/tests/fixtures/layout-github-requirement-username.yaml
+++ b/tests/fixtures/layout-github-requirement-username.yaml
@@ -1,0 +1,37 @@
+pipelines:
+  - name: pipeline
+    manager: IndependentPipelineManager
+    source: github
+    require:
+      approval:
+        - username: ^(herp|derp)$
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'test me'
+    success:
+      github:
+        comment: true
+
+#  - name: trigger
+#    manager: IndependentPipelineManager
+#    trigger:
+#      github:
+#        - event: pr-comment
+#          comment: 'test me'
+#          require-approval:
+#            - username: zuul
+#    success:
+#      github:
+#        comment: true
+#    failure:
+#      github:
+#        status: true
+
+projects:
+  - name: org/project1
+    pipeline:
+      - project1-pipeline
+#  - name: org/project2
+#    trigger:
+#      - project2-trigger

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -8,6 +8,10 @@ pipelines:
             - pr-open
             - pr-change
             - pr-reopen
+    success:
+      github: 'TEST PASSES'
+    failure:
+      github: 'TEST FAILED'
 
 projects:
   - name: org/project

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -13,9 +13,27 @@ pipelines:
     failure:
       github: 'TEST FAILED'
 
+  - name: post
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: push
+
+  - name: tag
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: tag
+
 projects:
   - name: org/project
     check:
       - project-merge:
         - project-test1
         - project-test2
+    post:
+      - project-post
+    tag:
+      - project-tag

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -74,6 +74,7 @@ pipelines:
     description: Pipeline for merging the pull request
     manager: IndependentPipelineManager
     source: github
+    merge-failure-message: 'Merge failed'
     trigger:
       github:
         - event: pr-comment

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -1,5 +1,6 @@
 pipelines:
   - name: check
+    description: Standard check
     manager: IndependentPipelineManager
     source: github
     trigger:
@@ -10,10 +11,35 @@ pipelines:
             - pr-reopen
         - event: pr-comment
           comment: 'test me'
+    start:
+      github:
+        status: true
     success:
-      github: 'TEST PASSES'
+      github:
+        status: true
+        comment: true
     failure:
-      github: 'TEST FAILED'
+      github:
+        status: true
+        comment: true
+
+  - name: reporting
+    description: Uncommon reporting
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'reporting check'
+    start:
+      github:
+        comment: true
+    success:
+      github:
+        comment: false
+    failure:
+      github:
+        comment: false
 
   - name: post
     manager: IndependentPipelineManager
@@ -39,3 +65,5 @@ projects:
       - project-post
     tag:
       - project-tag
+    reporting:
+      - project-test1

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -1,0 +1,17 @@
+pipelines:
+  - name: check
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event:
+            - pr-open
+            - pr-change
+            - pr-reopen
+
+projects:
+  - name: org/project
+    check:
+      - project-merge:
+        - project-test1
+        - project-test2

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -113,6 +113,9 @@ jobs:
   - name: ^.*-merge$
     failure-message: Unable to merge change
     hold-following-changes: true
+  - name: project-testfile
+    files:
+      - '.*-requires'
 
 projects:
   - name: org/project
@@ -138,3 +141,7 @@ projects:
   - name: org/one-job-project
     check:
       - one-job-project-merge
+
+  - name: org/project1
+    check:
+      - project-testfile

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -61,9 +61,14 @@ pipelines:
     success:
       github:
         comment: false
+        status: true
+        status_url: http://logs.example.com/{change.project.name}/{change.number}/{change.patchset}
     failure:
       github:
         comment: false
+        status: true
+        status_url: http://logs.example.com/{change.project.name}/{change.number}/{change.patchset}
+
 
   - name: merge
     description: Pipeline for merging the pull request

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -53,6 +53,23 @@ pipelines:
       github:
         merge: true
 
+  - name: labels
+    description: Trigger on labels
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: pr-label
+          label:
+            - 'test'
+            - '-do not test'
+
+    success:
+      github:
+        label:
+          - 'tests passed'
+          - '-test'
+
   - name: post
     manager: IndependentPipelineManager
     source: github
@@ -81,3 +98,5 @@ projects:
       - project-tag
     reporting:
       - project-test1
+    labels:
+      - project-labels

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -114,6 +114,21 @@ pipelines:
       github:
         - event: tag
 
+  - name: reviews
+    description: Trigger on review
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: pr-review
+          state: 'approve'
+
+    success:
+      github:
+        label:
+          - 'tests passed'
+          - '-test'
+
 jobs:
   - name: ^.*-merge$
     failure-message: Unable to merge change
@@ -142,6 +157,8 @@ projects:
       - project-test1
     labels:
       - project-labels
+    reviews:
+      - project-reviews
 
   - name: org/one-job-project
     check:

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -9,6 +9,7 @@ pipelines:
             - pr-open
             - pr-change
             - pr-reopen
+          branch: '^master$'
         - event: pr-comment
           comment: 'test me'
     start:
@@ -99,6 +100,7 @@ pipelines:
     trigger:
       github:
         - event: push
+          ref: '^refs/heads/master$'
 
   - name: tag
     manager: IndependentPipelineManager

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -100,3 +100,7 @@ projects:
       - project-test1
     labels:
       - project-labels
+
+  - name: org/one-job-project
+    check:
+      - one-job-project-merge

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -8,6 +8,8 @@ pipelines:
             - pr-open
             - pr-change
             - pr-reopen
+        - event: pr-comment
+          comment: 'test me'
     success:
       github: 'TEST PASSES'
     failure:

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -41,6 +41,18 @@ pipelines:
       github:
         comment: false
 
+  - name: merge
+    description: Pipeline for merging the pull request
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: pr-comment
+          comment: 'merge me'
+    success:
+      github:
+        merge: true
+
   - name: post
     manager: IndependentPipelineManager
     source: github
@@ -61,6 +73,8 @@ projects:
       - project-merge:
         - project-test1
         - project-test2
+    merge:
+      - noop
     post:
       - project-post
     tag:

--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -23,6 +23,29 @@ pipelines:
         status: true
         comment: true
 
+  - name: gate
+    description: Gatekeeping
+    manager: DependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event: pr-label
+          label: 'merge'
+    start:
+      github:
+        status: true
+    success:
+      github:
+        status: true
+        merge: true
+        label: '-merge'
+    failure:
+      github:
+        status: true
+        comment: true
+        label: '-merge'
+
+
   - name: reporting
     description: Uncommon reporting
     manager: IndependentPipelineManager
@@ -84,9 +107,18 @@ pipelines:
       github:
         - event: tag
 
+jobs:
+  - name: ^.*-merge$
+    failure-message: Unable to merge change
+    hold-following-changes: true
+
 projects:
   - name: org/project
     check:
+      - project-merge:
+        - project-test1
+        - project-test2
+    gate:
       - project-merge:
         - project-test1
         - project-test2

--- a/tests/fixtures/layout-template-cartesian.yaml
+++ b/tests/fixtures/layout-template-cartesian.yaml
@@ -1,0 +1,23 @@
+pipelines:
+  - name: 'check'
+    manager: IndependentPipelineManager
+    trigger:
+      gerrit:
+        - event: patchset-created
+
+project-templates:
+  - name: mytemplate
+    check:
+      - '{branch}-{test}'
+
+projects:
+  - name: organization/project
+    template:
+      - name: mytemplate
+        # creates jobs with cartisian product of the following lists
+        branch:
+          - master
+          - stable
+        test:
+          - unit
+          - regression

--- a/tests/fixtures/zuul-connections-gerrit-and-github.conf
+++ b/tests/fixtures/zuul-connections-gerrit-and-github.conf
@@ -1,0 +1,39 @@
+[gearman]
+server=127.0.0.1
+
+[zuul]
+layout_config=layout-connections-multiple-voters.yaml
+url_pattern=http://logs.example.com/{change.number}/{change.patchset}/{pipeline.name}/{job.name}/{build.number}
+job_name_in_report=true
+
+[merger]
+git_dir=/tmp/zuul-test/git
+git_user_email=zuul@example.com
+git_user_name=zuul
+zuul_url=http://zuul.example.com/p
+
+[swift]
+authurl=https://identity.api.example.org/v2.0/
+user=username
+key=password
+tenant_name=" "
+
+default_container=logs
+region_name=EXP
+logserver_prefix=http://logs.example.org/server.app/
+
+[connection gerrit]
+driver=gerrit
+server=review.example.com
+user=jenkins
+sshkey=none
+
+[connection github]
+driver=github
+
+[connection outgoing_smtp]
+driver=smtp
+server=localhost
+port=25
+default_from=zuul@example.com
+default_to=you@example.com

--- a/tests/fixtures/zuul-github.conf
+++ b/tests/fixtures/zuul-github.conf
@@ -24,3 +24,7 @@ logserver_prefix=http://logs.example.org/server.app/
 
 [connection github]
 driver=github
+
+[connection github_ssh]
+driver=github
+sshkey=/home/zuul/.ssh/id_rsa

--- a/tests/fixtures/zuul-github.conf
+++ b/tests/fixtures/zuul-github.conf
@@ -6,6 +6,7 @@ layout_config=layout-github.yaml
 url_pattern=http://logs.example.com/{change.number}/{change.patchset}/{pipeline.name}/{job.name}/{build.number}
 job_name_in_report=true
 status_url=http://zuul.example.com/status
+status_url_with_change=true
 
 [merger]
 git_dir=/tmp/zuul-test/git

--- a/tests/fixtures/zuul-github.conf
+++ b/tests/fixtures/zuul-github.conf
@@ -5,6 +5,7 @@ server=127.0.0.1
 layout_config=layout-github.yaml
 url_pattern=http://logs.example.com/{change.number}/{change.patchset}/{pipeline.name}/{job.name}/{build.number}
 job_name_in_report=true
+status_url=http://zuul.example.com/status
 
 [merger]
 git_dir=/tmp/zuul-test/git

--- a/tests/fixtures/zuul-github.conf
+++ b/tests/fixtures/zuul-github.conf
@@ -1,0 +1,26 @@
+[gearman]
+server=127.0.0.1
+
+[zuul]
+layout_config=layout-github.yaml
+url_pattern=http://logs.example.com/{change.number}/{change.patchset}/{pipeline.name}/{job.name}/{build.number}
+job_name_in_report=true
+
+[merger]
+git_dir=/tmp/zuul-test/git
+git_user_email=zuul@example.com
+git_user_name=zuul
+zuul_url=http://zuul.example.com/p
+
+[swift]
+authurl=https://identity.api.example.org/v2.0/
+user=username
+key=password
+tenant_name=" "
+
+default_container=logs
+region_name=EXP
+logserver_prefix=http://logs.example.org/server.app/
+
+[connection github]
+driver=github

--- a/tests/test_change_matcher.py
+++ b/tests/test_change_matcher.py
@@ -125,11 +125,17 @@ class TestMatchAllFiles(BaseTestMatcher):
     def test_matches_returns_false_when_not_all_files_match(self):
         self._test_matches(False, files=['/COMMIT_MSG', 'docs/foo', 'foo/bar'])
 
+    def test_matches_returns_true_when_single_file_does_not_match(self):
+        self._test_matches(True, files=['docs/foo'])
+
     def test_matches_returns_false_when_commit_message_matches(self):
         self._test_matches(False, files=['/COMMIT_MSG'])
 
     def test_matches_returns_true_when_all_files_match(self):
         self._test_matches(True, files=['/COMMIT_MSG', 'docs/foo'])
+
+    def test_matches_returns_true_when_single_file_matches(self):
+        self._test_matches(True, files=['docs/foo'])
 
 
 class TestMatchAll(BaseTestMatcher):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -28,6 +28,14 @@ class TestGerritConnection(testtools.TestCase):
                          zuul.connection.gerrit.GerritConnection.driver_name)
 
 
+class TestGitHubConnection(testtools.TestCase):
+    log = logging.getLogger("zuul.test_connection")
+
+    def test_driver_name(self):
+        self.assertEqual('github',
+                         zuul.connection.github.GithubConnection.driver_name)
+
+
 class TestConnections(ZuulTestCase):
     def setup_config(self, config_file='zuul-connections-same-gerrit.conf'):
         super(TestConnections, self).setup_config(config_file)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -234,17 +234,21 @@ class TestGithub(ZuulTestCase):
         self.waitUntilSettled()
         self.assertIn('check', A.statuses)
         check_status = A.statuses['check']
+        check_url = ('http://zuul.example.com/status/#%s,%s' %
+                     (A.number, A.head_sha))
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('pending', check_status['state'])
-        self.assertEqual('http://zuul.example.com/status', check_status['url'])
+        self.assertEqual(check_url, check_status['url'])
 
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
         check_status = A.statuses['check']
+        check_url = ('http://zuul.example.com/status/#%s,%s' %
+                     (A.number, A.head_sha))
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('success', check_status['state'])
-        self.assertEqual('http://zuul.example.com/status', check_status['url'])
+        self.assertEqual(check_url, check_status['url'])
 
         # pipeline does not report any status
         self.worker.hold_jobs_in_build = True

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -64,6 +64,15 @@ class TestGithub(ZuulTestCase):
         ))
         self.assertEqual(1, len(A.comments))
 
+    def test_pull_unmatched_branch_event(self):
+        self.create_branch('org/project', 'unmatched_branch')
+        A = self.fake_github.openFakePullRequest(
+            'org/project', 'unmatched_branch', 'A')
+        self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
+        self.waitUntilSettled()
+
+        self.assertEqual(0, len(self.history))
+
     def test_comment_event(self):
         A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
         self.fake_github.emitEvent(A.getCommentAddedEvent('test me'))
@@ -118,6 +127,16 @@ class TestGithub(ZuulTestCase):
 
         self.assertEqual('SUCCESS',
                          self.getJobFromHistory('project-post').result)
+
+    def test_push_unmatched_event(self):
+        old_sha = random_sha1()
+        new_sha = random_sha1()
+        self.fake_github.emitEvent(
+            self.fake_github.getPushEvent('org/project', 'unmatched_branch',
+                                          old_sha, new_sha))
+        self.waitUntilSettled()
+
+        self.assertEqual(0, len(self.history))
 
     def test_label_added_event(self):
         A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,64 @@
+# Copyright 2015 GoodData
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import re
+from testtools.matchers import MatchesRegex
+
+from tests.base import ZuulTestCase
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s %(name)-32s '
+                    '%(levelname)-8s %(message)s')
+
+
+class TestGithub(ZuulTestCase):
+
+    def setup_config(self, config_file='zuul-github.conf'):
+        super(TestGithub, self).setup_config(config_file)
+
+    def test_pull_event(self):
+        self.worker.registerFunction('set_description:' +
+                                     self.worker.worker_id)
+
+        self.worker.hold_jobs_in_build = True
+
+        pr = self.fake_github.openFakePullRequest('org/project', 'master')
+        self.fake_github.emitEvent(pr.getPullRequestOpenedEvent())
+        self.waitUntilSettled()
+
+        build_params = self.builds[0].parameters
+        self.assertEqual('master', build_params['ZUUL_BRANCH'])
+        self.assertEqual(str(pr.number), build_params['ZUUL_CHANGE'])
+        self.assertEqual(pr.head_sha, build_params['ZUUL_PATCHSET'])
+
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+
+        self.assertEqual('SUCCESS',
+                         self.getJobFromHistory('project-merge').result)
+        self.assertEqual('SUCCESS',
+                         self.getJobFromHistory('project-test1').result)
+        self.assertEqual('SUCCESS',
+                         self.getJobFromHistory('project-test2').result)
+
+        descr = self.getJobFromHistory('project-merge').description
+        self.assertThat(descr, MatchesRegex(
+            r'.*<\s*a\s+href='
+            '[\'"]https://github.com/org/project/pull/%s[\'"]'
+            '\s*>%s,%s<\s*/a\s*>' %
+            (pr.number, pr.number, pr.head_sha),
+            re.DOTALL
+        ))

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -73,6 +73,21 @@ class TestGithub(ZuulTestCase):
 
         self.assertEqual(0, len(self.history))
 
+    def test_pull_matched_file_event(self):
+        A = self.fake_github.openFakePullRequest(
+            'org/project1', 'master', 'A',
+            files=['random.txt', 'build-requires'])
+        self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
+        self.waitUntilSettled()
+        self.assertEqual(1, len(self.history))
+
+    def test_pull_unmatched_file_event(self):
+        A = self.fake_github.openFakePullRequest('org/project1', 'master', 'A',
+                                                 files=['random.txt'])
+        self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
+        self.waitUntilSettled()
+        self.assertEqual(0, len(self.history))
+
     def test_comment_event(self):
         A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
         self.fake_github.emitEvent(A.getCommentAddedEvent('test me'))

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -177,6 +177,20 @@ class TestGithub(ZuulTestCase):
         self.assertEqual(0, len(self.history))
         self.assertEqual(['other label'], A.labels)
 
+    def test_review_event(self):
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getReviewAddedEvent('approve'))
+        self.waitUntilSettled()
+        self.assertEqual(1, len(self.history))
+        self.assertEqual('project-reviews', self.history[0].name)
+        self.assertEqual(['tests passed'], A.labels)
+
+    def test_review_unmatched_event(self):
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getReviewAddedEvent('comment'))
+        self.waitUntilSettled()
+        self.assertEqual(0, len(self.history))
+
     def test_dequeue_pull_synchronized(self):
         self.worker.hold_jobs_in_build = True
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -355,6 +355,8 @@ class TestGithub(ZuulTestCase):
         self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
         self.waitUntilSettled()
         self.assertFalse(A.is_merged)
+        self.assertEqual(len(A.comments), 1)
+        self.assertEqual(A.comments[0], 'Merge failed')
 
     def test_parallel_changes(self):
         "Test that changes are tested in parallel and merged in series"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -16,7 +16,7 @@ import logging
 import re
 from testtools.matchers import MatchesRegex
 
-from tests.base import ZuulTestCase
+from tests.base import ZuulTestCase, random_sha1
 
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s %(name)-32s '
@@ -63,3 +63,46 @@ class TestGithub(ZuulTestCase):
             re.DOTALL
         ))
         self.assertEqual(1, len(pr.comments))
+
+    def test_tag_event(self):
+        self.worker.hold_jobs_in_build = True
+
+        sha = random_sha1()
+        self.fake_github.emitEvent(
+            self.fake_github.getTagEvent('org/project', 'newtag', sha))
+        self.waitUntilSettled()
+
+        build_params = self.builds[0].parameters
+        self.assertEqual('refs/tags/newtag', build_params['ZUUL_REF'])
+        self.assertEqual('00000000000000000000000000000000',
+                         build_params['ZUUL_OLDREV'])
+        self.assertEqual(sha, build_params['ZUUL_NEWREV'])
+
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+
+        self.assertEqual('SUCCESS',
+                         self.getJobFromHistory('project-tag').result)
+
+    def test_push_event(self):
+        self.worker.hold_jobs_in_build = True
+
+        old_sha = random_sha1()
+        new_sha = random_sha1()
+        self.fake_github.emitEvent(
+            self.fake_github.getPushEvent('org/project', 'master',
+                                          old_sha, new_sha))
+        self.waitUntilSettled()
+
+        build_params = self.builds[0].parameters
+        self.assertEqual('refs/heads/master', build_params['ZUUL_REF'])
+        self.assertEqual(old_sha, build_params['ZUUL_OLDREV'])
+        self.assertEqual(new_sha, build_params['ZUUL_NEWREV'])
+
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+
+        self.assertEqual('SUCCESS',
+                         self.getJobFromHistory('project-post').result)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -128,3 +128,62 @@ class TestGithub(ZuulTestCase):
         """Test that git_ssh option gives git url with ssh"""
         url = self.fake_github_ssh.real_getGitUrl('org/project')
         self.assertEqual('ssh://git@github.com/org/project.git', url)
+
+    def test_report_pull_status(self):
+        # pipeline reports pull status both on start and success
+        self.worker.hold_jobs_in_build = True
+        pr = self.fake_github.openFakePullRequest('org/project', 'master')
+        self.fake_github.emitEvent(pr.getPullRequestOpenedEvent())
+        self.waitUntilSettled()
+        self.assertIn('check', pr.statuses)
+        check_status = pr.statuses['check']
+        self.assertEqual('Standard check', check_status['description'])
+        self.assertEqual('pending', check_status['state'])
+        self.assertEqual('http://zuul.example.com/status', check_status['url'])
+
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+        check_status = pr.statuses['check']
+        self.assertEqual('Standard check', check_status['description'])
+        self.assertEqual('success', check_status['state'])
+        self.assertEqual('http://zuul.example.com/status', check_status['url'])
+
+        # pipeline does not report any status
+        self.worker.hold_jobs_in_build = True
+        self.fake_github.emitEvent(
+            pr.getCommentAddedEvent('reporting check'))
+        self.waitUntilSettled()
+        self.assertNotIn('reporting', pr.statuses)
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+        self.assertNotIn('reporting', pr.statuses)
+
+    def test_report_pull_comment(self):
+        # pipeline reports comment on success
+        self.worker.hold_jobs_in_build = True
+        pr = self.fake_github.openFakePullRequest('org/project', 'master')
+        self.fake_github.emitEvent(pr.getPullRequestOpenedEvent())
+        self.waitUntilSettled()
+        self.assertEqual(0, len(pr.comments))
+
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+        self.assertEqual(1, len(pr.comments))
+        self.assertThat(pr.comments[0],
+                        MatchesRegex('.*Build succeeded.*', re.DOTALL))
+
+        # pipeline reports comment on start
+        self.worker.hold_jobs_in_build = True
+        self.fake_github.emitEvent(
+            pr.getCommentAddedEvent('reporting check'))
+        self.waitUntilSettled()
+        self.assertEqual(2, len(pr.comments))
+        self.assertThat(pr.comments[1],
+                        MatchesRegex('.*Starting reporting jobs.*', re.DOTALL))
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+        self.assertEqual(2, len(pr.comments))

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -62,3 +62,4 @@ class TestGithub(ZuulTestCase):
             (pr.number, pr.number, pr.head_sha),
             re.DOTALL
         ))
+        self.assertEqual(1, len(pr.comments))

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -232,10 +232,14 @@ class TestGithub(ZuulTestCase):
         A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
         self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
         self.waitUntilSettled()
-        self.assertIn('check', A.statuses)
-        check_status = A.statuses['check']
+        # We should have a status container for the head sha
+        self.assertIn(A.head_sha, A.statuses.keys())
+        # We should only have one status for the head sha
+        self.assertEqual(1, len(A.statuses[A.head_sha]))
+        check_status = A.statuses[A.head_sha][0]
         check_url = ('http://zuul.example.com/status/#%s,%s' %
                      (A.number, A.head_sha))
+        self.assertEqual('check', check_status['context'])
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('pending', check_status['state'])
         self.assertEqual(check_url, check_status['url'])
@@ -243,9 +247,12 @@ class TestGithub(ZuulTestCase):
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
-        check_status = A.statuses['check']
+        # We should only have two statuses for the head sha
+        self.assertEqual(2, len(A.statuses[A.head_sha]))
+        check_status = A.statuses[A.head_sha][0]
         check_url = ('http://zuul.example.com/status/#%s,%s' %
                      (A.number, A.head_sha))
+        self.assertEqual('check', check_status['context'])
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('success', check_status['state'])
         self.assertEqual(check_url, check_status['url'])
@@ -255,18 +262,20 @@ class TestGithub(ZuulTestCase):
         self.fake_github.emitEvent(
             A.getCommentAddedEvent('reporting check'))
         self.waitUntilSettled()
-        # pipeline does not report start status
-        self.assertNotIn('reporting', A.statuses)
+        # pipeline does not report start status, we should only have 2
+        self.assertEqual(2, len(A.statuses[A.head_sha]))
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
         # pipeline reports success/failure status
-        self.assertIn('reporting', A.statuses)
-        report_status = A.statuses['reporting']
+        self.assertEqual(3, len(A.statuses[A.head_sha]))
+        report_status = A.statuses[A.head_sha][0]
         status_url = report_status['url']
         expected_url = ('http://logs.example.com/org/project/1/%s' %
                         A.head_sha)
         self.assertEqual(expected_url, status_url)
+        self.assertEqual('reporting', report_status['context'])
+        self.assertEqual('success', report_status['state'])
 
     def test_report_pull_comment(self):
         # pipeline reports comment on success

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -118,6 +118,30 @@ class TestGithub(ZuulTestCase):
         self.assertEqual('SUCCESS',
                          self.getJobFromHistory('project-post').result)
 
+    def test_label_added_event(self):
+        pr = self.fake_github.openFakePullRequest('org/project', 'master')
+        self.fake_github.emitEvent(pr.addLabel('test'))
+        self.waitUntilSettled()
+        self.assertEqual(1, len(self.history))
+        self.assertEqual('project-labels', self.history[0].name)
+        self.assertEqual(['tests passed'], pr.labels)
+
+    def test_label_removed_event(self):
+        pr = self.fake_github.openFakePullRequest('org/project', 'master')
+        pr.addLabel('do not test')
+        self.fake_github.emitEvent(pr.removeLabel('do not test'))
+        self.waitUntilSettled()
+        self.assertEqual(1, len(self.history))
+        self.assertEqual('project-labels', self.history[0].name)
+        self.assertEqual(['tests passed'], pr.labels)
+
+    def test_label_added_unmatched_event(self):
+        pr = self.fake_github.openFakePullRequest('org/project', 'master')
+        self.fake_github.emitEvent(pr.addLabel('other label'))
+        self.waitUntilSettled()
+        self.assertEqual(0, len(self.history))
+        self.assertEqual(['other label'], pr.labels)
+
     def test_git_https_url(self):
         """Test that git_ssh option gives git url with ssh"""
         url = self.fake_github.real_getGitUrl('org/project')

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -34,14 +34,14 @@ class TestGithub(ZuulTestCase):
 
         self.worker.hold_jobs_in_build = True
 
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.getPullRequestOpenedEvent())
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
         self.waitUntilSettled()
 
         build_params = self.builds[0].parameters
         self.assertEqual('master', build_params['ZUUL_BRANCH'])
-        self.assertEqual(str(pr.number), build_params['ZUUL_CHANGE'])
-        self.assertEqual(pr.head_sha, build_params['ZUUL_PATCHSET'])
+        self.assertEqual(str(A.number), build_params['ZUUL_CHANGE'])
+        self.assertEqual(A.head_sha, build_params['ZUUL_PATCHSET'])
 
         self.worker.hold_jobs_in_build = False
         self.worker.release()
@@ -59,20 +59,20 @@ class TestGithub(ZuulTestCase):
             r'.*<\s*a\s+href='
             '[\'"]https://github.com/org/project/pull/%s[\'"]'
             '\s*>%s,%s<\s*/a\s*>' %
-            (pr.number, pr.number, pr.head_sha),
+            (A.number, A.number, A.head_sha),
             re.DOTALL
         ))
-        self.assertEqual(1, len(pr.comments))
+        self.assertEqual(1, len(A.comments))
 
     def test_comment_event(self):
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.getCommentAddedEvent('test me'))
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getCommentAddedEvent('test me'))
         self.waitUntilSettled()
         self.assertEqual(3, len(self.history))
 
     def test_comment_unmatched_event(self):
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.getCommentAddedEvent('casual comment'))
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getCommentAddedEvent('casual comment'))
         self.waitUntilSettled()
         self.assertEqual(0, len(self.history))
 
@@ -120,42 +120,42 @@ class TestGithub(ZuulTestCase):
                          self.getJobFromHistory('project-post').result)
 
     def test_label_added_event(self):
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.addLabel('test'))
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.addLabel('test'))
         self.waitUntilSettled()
         self.assertEqual(1, len(self.history))
         self.assertEqual('project-labels', self.history[0].name)
-        self.assertEqual(['tests passed'], pr.labels)
+        self.assertEqual(['tests passed'], A.labels)
 
     def test_label_removed_event(self):
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        pr.addLabel('do not test')
-        self.fake_github.emitEvent(pr.removeLabel('do not test'))
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        A.addLabel('do not test')
+        self.fake_github.emitEvent(A.removeLabel('do not test'))
         self.waitUntilSettled()
         self.assertEqual(1, len(self.history))
         self.assertEqual('project-labels', self.history[0].name)
-        self.assertEqual(['tests passed'], pr.labels)
+        self.assertEqual(['tests passed'], A.labels)
 
     def test_label_added_unmatched_event(self):
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.addLabel('other label'))
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.addLabel('other label'))
         self.waitUntilSettled()
         self.assertEqual(0, len(self.history))
-        self.assertEqual(['other label'], pr.labels)
+        self.assertEqual(['other label'], A.labels)
 
     def test_dequeue_pull_synchronized(self):
         self.worker.hold_jobs_in_build = True
 
-        pr = self.fake_github.openFakePullRequest(
-            'org/one-job-project', 'master')
-        self.fake_github.emitEvent(pr.getPullRequestOpenedEvent())
+        A = self.fake_github.openFakePullRequest(
+            'org/one-job-project', 'master', 'A')
+        self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
         self.waitUntilSettled()
 
         # event update stamp has resolution one second, wait so the latter
         # one has newer timestamp
         time.sleep(1)
-        pr.addCommit()
-        self.fake_github.emitEvent(pr.getPullRequestSynchronizeEvent())
+        A.addCommit()
+        self.fake_github.emitEvent(A.getPullRequestSynchronizeEvent())
         self.waitUntilSettled()
 
         self.worker.hold_jobs_in_build = False
@@ -168,11 +168,11 @@ class TestGithub(ZuulTestCase):
     def test_dequeue_pull_abandoned(self):
         self.worker.hold_jobs_in_build = True
 
-        pr = self.fake_github.openFakePullRequest(
-            'org/one-job-project', 'master')
-        self.fake_github.emitEvent(pr.getPullRequestOpenedEvent())
+        A = self.fake_github.openFakePullRequest(
+            'org/one-job-project', 'master', 'A')
+        self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
         self.waitUntilSettled()
-        self.fake_github.emitEvent(pr.getPullRequestClosedEvent())
+        self.fake_github.emitEvent(A.getPullRequestClosedEvent())
         self.waitUntilSettled()
 
         self.worker.hold_jobs_in_build = False
@@ -195,11 +195,11 @@ class TestGithub(ZuulTestCase):
     def test_report_pull_status(self):
         # pipeline reports pull status both on start and success
         self.worker.hold_jobs_in_build = True
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.getPullRequestOpenedEvent())
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
         self.waitUntilSettled()
-        self.assertIn('check', pr.statuses)
-        check_status = pr.statuses['check']
+        self.assertIn('check', A.statuses)
+        check_status = A.statuses['check']
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('pending', check_status['state'])
         self.assertEqual('http://zuul.example.com/status', check_status['url'])
@@ -207,7 +207,7 @@ class TestGithub(ZuulTestCase):
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
-        check_status = pr.statuses['check']
+        check_status = A.statuses['check']
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('success', check_status['state'])
         self.assertEqual('http://zuul.example.com/status', check_status['url'])
@@ -215,63 +215,63 @@ class TestGithub(ZuulTestCase):
         # pipeline does not report any status
         self.worker.hold_jobs_in_build = True
         self.fake_github.emitEvent(
-            pr.getCommentAddedEvent('reporting check'))
+            A.getCommentAddedEvent('reporting check'))
         self.waitUntilSettled()
-        self.assertNotIn('reporting', pr.statuses)
+        self.assertNotIn('reporting', A.statuses)
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
-        self.assertNotIn('reporting', pr.statuses)
+        self.assertNotIn('reporting', A.statuses)
 
     def test_report_pull_comment(self):
         # pipeline reports comment on success
         self.worker.hold_jobs_in_build = True
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.getPullRequestOpenedEvent())
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getPullRequestOpenedEvent())
         self.waitUntilSettled()
-        self.assertEqual(0, len(pr.comments))
+        self.assertEqual(0, len(A.comments))
 
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
-        self.assertEqual(1, len(pr.comments))
-        self.assertThat(pr.comments[0],
+        self.assertEqual(1, len(A.comments))
+        self.assertThat(A.comments[0],
                         MatchesRegex('.*Build succeeded.*', re.DOTALL))
 
         # pipeline reports comment on start
         self.worker.hold_jobs_in_build = True
         self.fake_github.emitEvent(
-            pr.getCommentAddedEvent('reporting check'))
+            A.getCommentAddedEvent('reporting check'))
         self.waitUntilSettled()
-        self.assertEqual(2, len(pr.comments))
-        self.assertThat(pr.comments[1],
+        self.assertEqual(2, len(A.comments))
+        self.assertThat(A.comments[1],
                         MatchesRegex('.*Starting reporting jobs.*', re.DOTALL))
         self.worker.hold_jobs_in_build = False
         self.worker.release()
         self.waitUntilSettled()
-        self.assertEqual(2, len(pr.comments))
+        self.assertEqual(2, len(A.comments))
 
     def test_report_pull_merge(self):
         # pipeline merges the pull request on success
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.getCommentAddedEvent('merge me'))
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
         self.waitUntilSettled()
-        self.assertTrue(pr.is_merged)
+        self.assertTrue(A.is_merged)
 
     def test_report_pull_merge_failure(self):
         # pipeline merges the pull request on success
         self.fake_github.merge_failure = True
-        pr = self.fake_github.openFakePullRequest('org/project', 'master')
-        self.fake_github.emitEvent(pr.getCommentAddedEvent('merge me'))
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
         self.waitUntilSettled()
-        self.assertFalse(pr.is_merged)
+        self.assertFalse(A.is_merged)
         self.fake_github.merge_failure = False
 
     def test_report_pull_merge_not_allowed_once(self):
         # pipeline merges the pull request on second run of merge
         # first merge failed on 405 Method Not Allowed error
         self.fake_github.merge_not_allowed_count = 1
-        A = self.fake_github.openFakePullRequest('org/project', 'master')
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
         self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
         self.waitUntilSettled()
         self.assertTrue(A.is_merged)
@@ -280,7 +280,177 @@ class TestGithub(ZuulTestCase):
         # pipeline does not merge the pull request
         # merge failed on 405 Method Not Allowed error - twice
         self.fake_github.merge_not_allowed_count = 2
-        A = self.fake_github.openFakePullRequest('org/project', 'master')
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
         self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
         self.waitUntilSettled()
         self.assertFalse(A.is_merged)
+
+    def test_parallel_changes(self):
+        "Test that changes are tested in parallel and merged in series"
+
+        self.worker.hold_jobs_in_build = True
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        B = self.fake_github.openFakePullRequest('org/project', 'master', 'B')
+        C = self.fake_github.openFakePullRequest('org/project', 'master', 'C')
+
+        self.fake_github.emitEvent(A.addLabel('merge'))
+        self.fake_github.emitEvent(B.addLabel('merge'))
+        self.fake_github.emitEvent(C.addLabel('merge'))
+
+        self.waitUntilSettled()
+        self.assertEqual(len(self.builds), 1)
+        self.assertEqual(self.builds[0].name, 'project-merge')
+        self.assertTrue(self.job_has_changes(self.builds[0], A))
+
+        self.worker.release('.*-merge')
+        self.waitUntilSettled()
+        self.assertEqual(len(self.builds), 3)
+        self.assertEqual(self.builds[0].name, 'project-test1')
+        self.assertTrue(self.job_has_changes(self.builds[0], A))
+        self.assertEqual(self.builds[1].name, 'project-test2')
+        self.assertTrue(self.job_has_changes(self.builds[1], A))
+        self.assertEqual(self.builds[2].name, 'project-merge')
+        self.assertTrue(self.job_has_changes(self.builds[2], A, B))
+
+        self.worker.release('.*-merge')
+        self.waitUntilSettled()
+        self.assertEqual(len(self.builds), 5)
+        self.assertEqual(self.builds[0].name, 'project-test1')
+        self.assertTrue(self.job_has_changes(self.builds[0], A))
+        self.assertEqual(self.builds[1].name, 'project-test2')
+        self.assertTrue(self.job_has_changes(self.builds[1], A))
+
+        self.assertEqual(self.builds[2].name, 'project-test1')
+        self.assertTrue(self.job_has_changes(self.builds[2], A, B))
+        self.assertEqual(self.builds[3].name, 'project-test2')
+        self.assertTrue(self.job_has_changes(self.builds[3], A, B))
+
+        self.assertEqual(self.builds[4].name, 'project-merge')
+        self.assertTrue(self.job_has_changes(self.builds[4], A, B, C))
+
+        self.worker.release('.*-merge')
+        self.waitUntilSettled()
+        self.assertEqual(len(self.builds), 6)
+        self.assertEqual(self.builds[0].name, 'project-test1')
+        self.assertTrue(self.job_has_changes(self.builds[0], A))
+        self.assertEqual(self.builds[1].name, 'project-test2')
+        self.assertTrue(self.job_has_changes(self.builds[1], A))
+
+        self.assertEqual(self.builds[2].name, 'project-test1')
+        self.assertTrue(self.job_has_changes(self.builds[2], A, B))
+        self.assertEqual(self.builds[3].name, 'project-test2')
+        self.assertTrue(self.job_has_changes(self.builds[3], A, B))
+
+        self.assertEqual(self.builds[4].name, 'project-test1')
+        self.assertTrue(self.job_has_changes(self.builds[4], A, B, C))
+        self.assertEqual(self.builds[5].name, 'project-test2')
+        self.assertTrue(self.job_has_changes(self.builds[5], A, B, C))
+
+        all_builds = self.builds[:]
+        self.release(all_builds[2])
+        self.release(all_builds[3])
+        self.waitUntilSettled()
+        self.assertFalse(A.is_merged)
+        self.assertFalse(B.is_merged)
+        self.assertFalse(C.is_merged)
+
+        self.release(all_builds[0])
+        self.release(all_builds[1])
+        self.waitUntilSettled()
+        self.assertTrue(A.is_merged)
+        self.assertTrue(B.is_merged)
+        self.assertFalse(C.is_merged)
+
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+        self.assertEqual(len(self.builds), 0)
+        self.assertEqual(len(self.history), 9)
+        self.assertTrue(C.is_merged)
+
+        self.assertNotIn('merge', A.labels)
+        self.assertNotIn('merge', B.labels)
+        self.assertNotIn('merge', C.labels)
+
+    def test_failed_changes(self):
+        "Test that a change behind a failed change is retested"
+        self.worker.hold_jobs_in_build = True
+
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        B = self.fake_github.openFakePullRequest('org/project', 'master', 'B')
+
+        self.worker.addFailTest('project-test1', A)
+
+        self.fake_github.emitEvent(A.addLabel('merge'))
+        self.fake_github.emitEvent(B.addLabel('merge'))
+        self.waitUntilSettled()
+
+        self.worker.release('.*-merge')
+        self.waitUntilSettled()
+
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+
+        self.waitUntilSettled()
+        # It's certain that the merge job for change 2 will run, but
+        # the test1 and test2 jobs may or may not run.
+        self.assertTrue(len(self.history) > 6)
+        self.assertFalse(A.is_merged)
+        self.assertTrue(B.is_merged)
+        self.assertNotIn('merge', A.labels)
+        self.assertNotIn('merge', B.labels)
+
+    def test_failed_change_at_head(self):
+        "Test that if a change at the head fails, jobs behind it are canceled"
+
+        self.worker.hold_jobs_in_build = True
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        B = self.fake_github.openFakePullRequest('org/project', 'master', 'B')
+        C = self.fake_github.openFakePullRequest('org/project', 'master', 'C')
+
+        self.worker.addFailTest('project-test1', A)
+
+        self.fake_github.emitEvent(A.addLabel('merge'))
+        self.fake_github.emitEvent(B.addLabel('merge'))
+        self.fake_github.emitEvent(C.addLabel('merge'))
+
+        self.waitUntilSettled()
+
+        self.assertEqual(len(self.builds), 1)
+        self.assertEqual(self.builds[0].name, 'project-merge')
+        self.assertTrue(self.job_has_changes(self.builds[0], A))
+
+        self.worker.release('.*-merge')
+        self.waitUntilSettled()
+        self.worker.release('.*-merge')
+        self.waitUntilSettled()
+        self.worker.release('.*-merge')
+        self.waitUntilSettled()
+
+        self.assertEqual(len(self.builds), 6)
+        self.assertEqual(self.builds[0].name, 'project-test1')
+        self.assertEqual(self.builds[1].name, 'project-test2')
+        self.assertEqual(self.builds[2].name, 'project-test1')
+        self.assertEqual(self.builds[3].name, 'project-test2')
+        self.assertEqual(self.builds[4].name, 'project-test1')
+        self.assertEqual(self.builds[5].name, 'project-test2')
+
+        self.release(self.builds[0])
+        self.waitUntilSettled()
+
+        # project-test2, project-merge for B
+        self.assertEqual(len(self.builds), 2)
+        self.assertEqual(self.countJobResults(self.history, 'ABORTED'), 4)
+
+        self.worker.hold_jobs_in_build = False
+        self.worker.release()
+        self.waitUntilSettled()
+
+        self.assertEqual(len(self.builds), 0)
+        self.assertEqual(len(self.history), 15)
+        self.assertFalse(A.is_merged)
+        self.assertTrue(B.is_merged)
+        self.assertTrue(C.is_merged)
+        self.assertNotIn('merge', A.labels)
+        self.assertNotIn('merge', B.labels)
+        self.assertNotIn('merge', C.labels)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -64,6 +64,18 @@ class TestGithub(ZuulTestCase):
         ))
         self.assertEqual(1, len(pr.comments))
 
+    def test_comment_event(self):
+        pr = self.fake_github.openFakePullRequest('org/project', 'master')
+        self.fake_github.emitEvent(pr.getCommentAddedEvent('test me'))
+        self.waitUntilSettled()
+        self.assertEqual(3, len(self.history))
+
+    def test_comment_unmatched_event(self):
+        pr = self.fake_github.openFakePullRequest('org/project', 'master')
+        self.fake_github.emitEvent(pr.getCommentAddedEvent('casual comment'))
+        self.waitUntilSettled()
+        self.assertEqual(0, len(self.history))
+
     def test_tag_event(self):
         self.worker.hold_jobs_in_build = True
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -272,10 +272,13 @@ class TestGithub(ZuulTestCase):
 
     def test_report_pull_merge(self):
         # pipeline merges the pull request on success
-        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        A = self.fake_github.openFakePullRequest('org/project', 'master',
+                                                 'PR title')
         self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
         self.waitUntilSettled()
         self.assertTrue(A.is_merged)
+        self.assertThat(A.merge_message,
+                        MatchesRegex('.*PR title.*Reviewed-by.*', re.DOTALL))
 
     def test_report_pull_merge_failure(self):
         # pipeline merges the pull request on success

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -118,3 +118,13 @@ class TestGithub(ZuulTestCase):
 
         self.assertEqual('SUCCESS',
                          self.getJobFromHistory('project-post').result)
+
+    def test_git_https_url(self):
+        """Test that git_ssh option gives git url with ssh"""
+        url = self.fake_github.real_getGitUrl('org/project')
+        self.assertEqual('https://github.com/org/project', url)
+
+    def test_git_ssh_url(self):
+        """Test that git_ssh option gives git url with ssh"""
+        url = self.fake_github_ssh.real_getGitUrl('org/project')
+        self.assertEqual('ssh://git@github.com/org/project.git', url)

--- a/tests/test_github_requirements.py
+++ b/tests/test_github_requirements.py
@@ -16,6 +16,11 @@
 
 import logging
 
+from zuul.source.github import (
+    REVIEW_APPROVED,
+    REVIEW_CHANGES_REQUESTED,
+)
+
 from tests.base import ZuulTestCase
 
 logging.basicConfig(level=logging.DEBUG,
@@ -115,7 +120,7 @@ class TestGithubRequirements(ZuulTestCase):
         self.assertEqual(len(self.history), 0)
 
         # Add an approval (review) from derp
-        A.addReview('derp', 'APPROVE')
+        A.addReview('derp', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 1)
@@ -148,19 +153,19 @@ class TestGithubRequirements(ZuulTestCase):
         self.assertEqual(len(self.history), 0)
 
         # A -2 from derp should not cause it to be enqueued
-        A.addReview('derp', 'REQUEST_CHANGES')
+        A.addReview('derp', REVIEW_CHANGES_REQUESTED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +1 from nobody should not cause it to be enqueued
-        A.addReview('nobody', 'APPROVE')
+        A.addReview('nobody', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +2 from derp should cause it to be enqueued
-        A.addReview('derp', 'APPROVE')
+        A.addReview('derp', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 1)
@@ -194,25 +199,25 @@ class TestGithubRequirements(ZuulTestCase):
         self.assertEqual(len(self.history), 0)
 
         # A -2 from derp should not cause it to be enqueued
-        A.addReview('derp', 'REQUEST_CHANGES')
+        A.addReview('derp', REVIEW_CHANGES_REQUESTED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +1 from nobody should not cause it to be enqueued
-        A.addReview('nobody', 'APPROVE')
+        A.addReview('nobody', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +2 from herp should not cause it to be enqueued
-        A.addReview('herp', 'APPROVE')
+        A.addReview('herp', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
         # A +2 from derp should cause it to be enqueued
-        A.addReview('derp', 'APPROVE')
+        A.addReview('derp', REVIEW_APPROVED)
         self.fake_github.emitEvent(comment)
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 1)

--- a/tests/test_github_requirements.py
+++ b/tests/test_github_requirements.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2016 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from tests.base import ZuulTestCase
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s %(name)-32s '
+                    '%(levelname)-8s %(message)s')
+
+
+class TestGithubRequirements(ZuulTestCase):
+    """Test pipeline and trigger requirements"""
+
+    def setup_config(self, config_file='zuul-github.conf'):
+        super(TestGithubRequirements, self).setup_config(config_file)
+
+    def test_pipeline_require_status(self):
+        "Test pipeline requirement: status"
+        return self._test_require_status('org/project1',
+                                         'project1-pipeline')
+
+#    def test_trigger_require_status(self):
+#        "Test trigger requirement: status"
+#        return self._test_require_status('org/project2',
+#                                         'project2-trigger')
+
+    def _test_require_status(self, project, job):
+        self.config.set('zuul', 'layout_config',
+                        'tests/fixtures/layout-github-requirement-status.yaml')
+        self.sched.reconfigure(self.config)
+        self.registerJobs()
+
+        A = self.fake_github.openFakePullRequest(project, 'master', 'A')
+        # A comment event that we will keep submitting to trigger
+        comment = A.getCommentAddedEvent('test me')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        # No status from zuul so should not be enqueued
+        self.assertEqual(len(self.history), 0)
+
+        # An error status should not cause it to be enqueued
+        A.setStatus(A.head_sha, 'error', 'null', 'null', 'check')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A success status goes in
+        A.setStatus(A.head_sha, 'success', 'null', 'null', 'check')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 1)
+        self.assertEqual(self.history[0].name, job)
+
+# TODO: Implement reject on status

--- a/tests/test_github_requirements.py
+++ b/tests/test_github_requirements.py
@@ -72,16 +72,150 @@ class TestGithubRequirements(ZuulTestCase):
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
-        # An success status from unknown user should not cause it to be
+        # A success status from unknown user should not cause it to be
         # enqueued
-        A.setStatus(A.head_sha, 'error', 'null', 'null', 'check', user='foo')
+        A.setStatus(A.head_sha, 'success', 'null', 'null', 'check', user='foo')
         self.fake_github.emitEvent(A.getCommitStatusEvent('error'))
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 0)
 
-        # A success status goes in
+        # A success status from zuul goes in
         A.setStatus(A.head_sha, 'success', 'null', 'null', 'check')
         self.fake_github.emitEvent(A.getCommitStatusEvent('success'))
         self.waitUntilSettled()
         self.assertEqual(len(self.history), 1)
         self.assertEqual(self.history[0].name, 'project2-trigger')
+
+# TODO: Implement reject on status
+
+    def test_pipeline_require_approval_username(self):
+        "Test pipeline requirement: approval username"
+        return self._test_require_approval_username('org/project1',
+                                                    'project1-pipeline')
+
+
+#    def test_trigger_require_approval_username(self):
+#        "Test pipeline requirement: approval username"
+#        return self._test_require_approval_username('org/project2',
+#                                                    'project2-trigger')
+
+    def _test_require_approval_username(self, project, job):
+        self.config.set(
+            'zuul', 'layout_config',
+            'tests/fixtures/layout-github-requirement-username.yaml')
+        self.sched.reconfigure(self.config)
+        self.registerJobs()
+
+        A = self.fake_github.openFakePullRequest(project, 'master', 'A')
+        # A comment event that we will keep submitting to trigger
+        comment = A.getCommentAddedEvent('test me')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        # No approval from derp so should not be enqueued
+        self.assertEqual(len(self.history), 0)
+
+        # Add an approval (review) from derp
+        A.addReview('derp', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 1)
+        self.assertEqual(self.history[0].name, job)
+
+    def test_pipeline_require_approval_state(self):
+        "Test pipeline requirement: approval state"
+        return self._test_require_approval_state('org/project1',
+                                                 'project1-pipeline')
+
+#    def test_trigger_require_approval_state(self):
+#        "Test pipeline requirement: approval state"
+#        return self._test_require_approval_state('org/project2',
+#                                                 'project2-trigger')
+
+    def _test_require_approval_state(self, project, job):
+        self.config.set('zuul', 'layout_config',
+                        'tests/fixtures/layout-github-requirement-state.yaml')
+        self.sched.reconfigure(self.config)
+        self.registerJobs()
+
+        A = self.fake_github.openFakePullRequest(project, 'master', 'A')
+        # Add derp to writers
+        A.writers.append('derp')
+        # A comment event that we will keep submitting to trigger
+        comment = A.getCommentAddedEvent('test me')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        # No positive approval from derp so should not be enqueued
+        self.assertEqual(len(self.history), 0)
+
+        # A -2 from derp should not cause it to be enqueued
+        A.addReview('derp', 'REQUEST_CHANGES')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +1 from nobody should not cause it to be enqueued
+        A.addReview('nobody', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +2 from derp should cause it to be enqueued
+        A.addReview('derp', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 1)
+        self.assertEqual(self.history[0].name, job)
+
+    def test_pipeline_require_approval_user_state(self):
+        "Test pipeline requirement: approval state from user"
+        return self._test_require_approval_user_state('org/project1',
+                                                      'project1-pipeline')
+
+#    def test_trigger_require_approval_user_state(self):
+#        "Test pipeline requirement: approval state from user"
+#        return self._test_require_approval_user_state('org/project2',
+#                                                      'project2-trigger')
+
+    def _test_require_approval_user_state(self, project, job):
+        self.config.set(
+            'zuul', 'layout_config',
+            'tests/fixtures/layout-github-requirement-username-state.yaml')
+        self.sched.reconfigure(self.config)
+        self.registerJobs()
+
+        A = self.fake_github.openFakePullRequest(project, 'master', 'A')
+        # Add derp and herp to writers
+        A.writers.extend(('derp', 'herp'))
+        # A comment event that we will keep submitting to trigger
+        comment = A.getCommentAddedEvent('test me')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        # No positive approval from derp so should not be enqueued
+        self.assertEqual(len(self.history), 0)
+
+        # A -2 from derp should not cause it to be enqueued
+        A.addReview('derp', 'REQUEST_CHANGES')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +1 from nobody should not cause it to be enqueued
+        A.addReview('nobody', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +2 from herp should not cause it to be enqueued
+        A.addReview('herp', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 0)
+
+        # A +2 from derp should cause it to be enqueued
+        A.addReview('derp', 'APPROVE')
+        self.fake_github.emitEvent(comment)
+        self.waitUntilSettled()
+        self.assertEqual(len(self.history), 1)
+        self.assertEqual(self.history[0].name, job)
+
+# TODO: Implement reject on approval username/state

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,36 @@
+# Copyright 2016 GoodData
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+
+from tests.base import ZuulTestCase
+
+LAYOUT_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+
+class TestLayout(ZuulTestCase):
+    def test_template_cartesian(self):
+        """Tests that specifying lists for multiple keys create jobs according
+        to cartesian product of the lists"""
+        layout = self.get_template('layout-template-cartesian.yaml')
+        job_names = layout.jobs.keys()
+        self.assertIn('master-unit', job_names)
+        self.assertIn('master-regression', job_names)
+        self.assertIn('stable-unit', job_names)
+        self.assertIn('stable-regression', job_names)
+
+    def get_template(self, name):
+        """Returns parsed template"""
+        layout_path = os.path.join(LAYOUT_DIR, name)
+        return self.sched.testConfig(layout_path, self.connections)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -39,9 +39,19 @@ class TestJob(BaseTestCase):
         change.files = ['/COMMIT_MSG', 'docs/foo']
         self.assertFalse(self.job.changeMatches(change))
 
+    def test_change_matches_returns_false_for_single_matched_skip_if(self):
+        change = model.Change('project')
+        change.files = ['docs/foo']
+        self.assertFalse(self.job.changeMatches(change))
+
     def test_change_matches_returns_true_for_unmatched_skip_if(self):
         change = model.Change('project')
         change.files = ['/COMMIT_MSG', 'foo']
+        self.assertTrue(self.job.changeMatches(change))
+
+    def test_change_matches_returns_true_for_single_unmatched_skip_if(self):
+        change = model.Change('project')
+        change.files = ['foo']
         self.assertTrue(self.job.changeMatches(change))
 
     def test_copy_retains_skip_if(self):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -54,7 +54,7 @@ class TestGithubReporter(testtools.TestCase):
 
     def test_reporter_abc(self):
         # We only need to instantiate a class for this
-        reporter = zuul.reporter.github.GithubReporter(None)  # noqa
+        reporter = zuul.reporter.github.GithubReporter({})  # noqa
 
     def test_reporter_name(self):
         self.assertEqual('github', zuul.reporter.github.GithubReporter.name)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -44,3 +44,17 @@ class TestGerritReporter(testtools.TestCase):
 
     def test_reporter_name(self):
         self.assertEqual('gerrit', zuul.reporter.gerrit.GerritReporter.name)
+
+
+class TestGithubReporter(testtools.TestCase):
+    log = logging.getLogger("zuul.test_reporter")
+
+    def setUp(self):
+        super(TestGithubReporter, self).setUp()
+
+    def test_reporter_abc(self):
+        # We only need to instantiate a class for this
+        reporter = zuul.reporter.github.GithubReporter(None)  # noqa
+
+    def test_reporter_name(self):
+        self.assertEqual('github', zuul.reporter.github.GithubReporter.name)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -23,3 +23,10 @@ class TestGerritSource(testtools.TestCase):
 
     def test_source_name(self):
         self.assertEqual('gerrit', zuul.source.gerrit.GerritSource.name)
+
+
+class TestGithubSource(testtools.TestCase):
+    log = logging.getLogger("zuul.test_source")
+
+    def test_source_name(self):
+        self.assertEqual('github', zuul.source.github.GithubSource.name)

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -29,6 +29,17 @@ class TestGerritTrigger(testtools.TestCase):
         self.assertEqual('gerrit', zuul.trigger.gerrit.GerritTrigger.name)
 
 
+class TestGithubTrigger(testtools.TestCase):
+    log = logging.getLogger("zuul.test_trigger")
+
+    def test_trigger_abc(self):
+        # We only need to instantiate a class for this
+        zuul.trigger.github.GithubTrigger({})
+
+    def test_trigger_name(self):
+        self.assertEqual('github', zuul.trigger.github.GithubTrigger.name)
+
+
 class TestTimerTrigger(testtools.TestCase):
     log = logging.getLogger("zuul.test_trigger")
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -18,6 +18,7 @@
 import json
 
 from six.moves import urllib
+import webob
 
 from tests.base import ZuulTestCase
 
@@ -84,3 +85,16 @@ class TestWebapp(ZuulTestCase):
 
         self.assertEqual(1, len(data), data)
         self.assertEqual("org/project1", data[0]['project'], data)
+
+    def test_webapp_custom_handler(self):
+        def custom_handler(request):
+            return webob.Response(body='ok')
+
+        self.webapp.register_path('/custom', custom_handler)
+        req = urllib.request.Request(
+            "http://localhost:%s/custom" % self.port)
+        f = urllib.request.urlopen(req)
+        self.assertEqual('ok', f.read())
+
+        self.webapp.unregister_path('/custom')
+        self.assertRaises(urllib.error.HTTPError, urllib.request.urlopen, req)

--- a/zuul/change_matcher.py
+++ b/zuul/change_matcher.py
@@ -101,7 +101,9 @@ class MatchAllFiles(AbstractMatcherCollection):
         yield self.commit_regex
 
     def matches(self, change):
-        if not (hasattr(change, 'files') and len(change.files) > 1):
+        if not (hasattr(change, 'files') and change.files):
+            return False
+        if len(change.files) == 1 and self.commit_regex.match(change.files[0]):
             return False
         for file_ in change.files:
             matched_file = False

--- a/zuul/cmd/__init__.py
+++ b/zuul/cmd/__init__.py
@@ -24,6 +24,7 @@ import signal
 import sys
 import traceback
 
+import yaml
 yappi = extras.try_import('yappi')
 
 import zuul.lib.connections
@@ -86,7 +87,14 @@ class ZuulApp(object):
             if not os.path.exists(fp):
                 raise Exception("Unable to read logging config file at %s" %
                                 fp)
-            logging.config.fileConfig(fp)
+
+            if os.path.splitext(fp)[1] in ('.yml', '.yaml'):
+                with open(fp, 'r') as f:
+                    logging.config.dictConfig(yaml.safe_load(f))
+
+            else:
+                logging.config.fileConfig(fp)
+
         else:
             logging.basicConfig(level=logging.DEBUG)
 

--- a/zuul/cmd/server.py
+++ b/zuul/cmd/server.py
@@ -89,7 +89,7 @@ class Server(zuul.cmd.ZuulApp):
         self.sched = zuul.scheduler.Scheduler(self.config,
                                               testonly=True)
         self.configure_connections()
-        self.sched.registerConnections(self.connections, load=False)
+        self.sched.registerConnections(self.connections, None, load=False)
         layout = self.sched.testConfig(self.config.get('zuul',
                                                        'layout_config'),
                                        self.connections)
@@ -195,7 +195,7 @@ class Server(zuul.cmd.ZuulApp):
 
         self.log.info('Starting scheduler')
         self.sched.start()
-        self.sched.registerConnections(self.connections)
+        self.sched.registerConnections(self.connections, webapp)
         self.sched.reconfigure(self.config)
         self.sched.resume()
         self.log.info('Starting Webapp')

--- a/zuul/connection/__init__.py
+++ b/zuul/connection/__init__.py
@@ -69,3 +69,21 @@ class BaseConnection(object):
         This lets the user supply a list of change objects that are
         still in use.  Anything in our cache that isn't in the supplied
         list should be safe to remove from the cache."""
+
+    def registerWebapp(self, webapp):
+        self.webapp = webapp
+
+    def registerHttpHandler(self, path, handler):
+        """Add connection handler for HTTP URI.
+
+        Connection can use builtin HTTP server for listening on incoming event
+        requests. The resulting path will be /connection/connection_name/path.
+        """
+        self.webapp.register_path(self._connectionPath(path), handler)
+
+    def unregisterHttpHandler(self, path):
+        """Remove the connection handler for HTTP URI."""
+        self.webapp.unregister_path(self._connectionPath(path))
+
+    def _connectionPath(self, path):
+        return '/connection/%s/%s' % (self.connection_name, path)

--- a/zuul/connection/gerrit.py
+++ b/zuul/connection/gerrit.py
@@ -57,6 +57,7 @@ class GerritEventConnector(threading.Thread):
         now = time.time()
         time.sleep(max((ts + self.delay) - now, 0.0))
         event = TriggerEvent()
+        event.connection_name = self.connection.connection_name
         event.type = data.get('type')
         event.trigger_name = 'gerrit'
         change = data.get('change')

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -77,6 +77,7 @@ class GithubWebhookListener():
         base_repo = body.get('repository')
 
         event = GithubTriggerEvent()
+        event.connection_name = self.connection.connection_name
         event.trigger_name = 'github'
         event.project_name = base_repo.get('full_name')
 
@@ -178,6 +179,7 @@ class GithubWebhookListener():
 
     def _pull_request_to_event(self, pr_body):
         event = GithubTriggerEvent()
+        event.connection_name = self.connection.connection_name
         event.trigger_name = 'github'
 
         base = pr_body.get('base')

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -23,8 +23,8 @@ import github3
 from github3.exceptions import MethodNotAllowed
 
 from zuul.connection import BaseConnection
-from zuul.model import TriggerEvent
 from zuul.exceptions import MergeFailure
+from zuul.model import GithubTriggerEvent
 
 
 class GithubWebhookListener():
@@ -75,7 +75,7 @@ class GithubWebhookListener():
         body = request.json_body
         base_repo = body.get('repository')
 
-        event = TriggerEvent()
+        event = GithubTriggerEvent()
         event.trigger_name = 'github'
         event.project_name = base_repo.get('full_name')
 
@@ -174,7 +174,7 @@ class GithubWebhookListener():
         return True
 
     def _pull_request_to_event(self, pr_body):
-        event = TriggerEvent()
+        event = GithubTriggerEvent()
         event.trigger_name = 'github'
 
         base = pr_body.get('base')

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -336,7 +336,7 @@ class GithubConnection(BaseConnection):
         repository = self.github.repository(owner, project)
         self.log.debug('Calling create_status: sha: %s, state: %s, url: %s,'
                        ' description: %s, context: %s', sha, state, url,
-                                                        description, context)
+                       description, context)
         repository.create_status(sha, state, url, description, context)
         log_rate_limit(self.log, self.github)
 

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -474,7 +474,7 @@ class GithubConnection(BaseConnection):
         commit = repository.commit(sha)
         # make a list out of the statuses so that we complete our
         # API transaction
-        statuses = [status for status in commit.statuses()]
+        statuses = [status.as_dict() for status in commit.statuses()]
 
         log_rate_limit(self.log, self.github)
         return statuses

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -157,7 +157,7 @@ class GithubConnection(BaseConnection):
     def _authenticateGithubAPI(self):
         token = self.connection_config.get('api_token', None)
         if token is not None:
-            self.github = github3.login(token)
+            self.github = github3.login(token=token)
             self.log.info("Github API Authentication successful.")
         else:
             self.github = None
@@ -182,6 +182,11 @@ class GithubConnection(BaseConnection):
 
     def getPullUrl(self, project, number):
         return '%s/pull/%s' % (self.getGitwebUrl(project), number)
+
+    def report(self, owner, project, pr_number, message):
+        repository = self.github.repository(owner, project)
+        pull_request = repository.issue(pr_number)
+        pull_request.create_comment(message)
 
 
 def getSchema():

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -112,6 +112,12 @@ class GithubWebhookListener():
             event.type = 'pr-close'
         elif action == 'reopened':
             event.type = 'pr-reopen'
+        elif action == 'labeled':
+            event.type = 'pr-label'
+            event.label = body['label']['name']
+        elif action == 'unlabeled':
+            event.type = 'pr-label'
+            event.label = '-' + body['label']['name']
         else:
             return None
 
@@ -123,6 +129,16 @@ class GithubWebhookListener():
         action = body.get('action')
         if action != 'created':
             return
+        pr_body = self._issue_to_pull_request(body)
+        if pr_body is None:
+            return
+
+        event = self._pull_request_to_event(pr_body)
+        event.comment = body.get('comment').get('body')
+        event.type = 'pr-comment'
+        return event
+
+    def _issue_to_pull_request(self, body):
         number = body.get('issue').get('number')
         project_name = body.get('repository').get('full_name')
         owner, project = project_name.split('/')
@@ -130,12 +146,7 @@ class GithubWebhookListener():
         if pr_body is None:
             self.log.debug('Pull request #%s not found in project %s' %
                            (number, project_name))
-            return
-
-        event = self._pull_request_to_event(pr_body)
-        event.comment = body.get('comment').get('body')
-        event.type = 'pr-comment'
-        return event
+        return pr_body
 
     def _validate_signature(self, request):
         secret = self.connection.connection_config.get('webhook_token', None)
@@ -260,6 +271,14 @@ class GithubConnection(BaseConnection):
                         url='', description='', context=''):
         repository = self.github.repository(owner, project)
         repository.create_status(sha, state, url, description, context)
+
+    def labelPull(self, owner, project, pr_number, label):
+        pull_request = self.github.issue(owner, project, pr_number)
+        pull_request.add_label(label)
+
+    def unlabelPull(self, owner, project, pr_number, label):
+        pull_request = self.github.issue(owner, project, pr_number)
+        pull_request.remove_label(label)
 
 
 def getSchema():

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -328,11 +328,11 @@ class GithubConnection(BaseConnection):
 
     def setCommitStatus(self, owner, project, sha, state,
                         url='', description='', context=''):
-        log.debug('Setting commit status: %s', state)
+        self.log.debug('Setting commit status: %s', state)
         repository = self.github.repository(owner, project)
-        log.debug('Calling create_status: sha: %s, state: %s, url: %s,'
-                  ' description: %s, context: %s', sha, state, url,
-                                                   description, context)
+        self.log.debug('Calling create_status: sha: %s, state: %s, url: %s,'
+                       ' description: %s, context: %s', sha, state, url,
+                                                        description, context)
         repository.create_status(sha, state, url, description, context)
         log_rate_limit(self.log, self.github)
 

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -328,7 +328,11 @@ class GithubConnection(BaseConnection):
 
     def setCommitStatus(self, owner, project, sha, state,
                         url='', description='', context=''):
+        log.debug('Setting commit status: %s', state)
         repository = self.github.repository(owner, project)
+        log.debug('Calling create_status: sha: %s, state: %s, url: %s,'
+                  ' description: %s, context: %s', sha, state, url,
+                                                   description, context)
         repository.create_status(sha, state, url, description, context)
         log_rate_limit(self.log, self.github)
 

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -559,7 +559,7 @@ class GithubConnection(BaseConnection):
 
     def labelPull(self, owner, project, pr_number, label):
         pull_request = self.github.issue(owner, project, pr_number)
-        pull_request.add_label(label)
+        pull_request.add_labels(label)
         log_rate_limit(self.log, self.github)
 
     def unlabelPull(self, owner, project, pr_number, label):

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -240,10 +240,15 @@ class GithubConnection(BaseConnection):
     def getPull(self, owner, project, number):
         return self.github.pull_request(owner, project, number).to_json()
 
-    def report(self, owner, project, pr_number, message):
+    def commentPull(self, owner, project, pr_number, message):
         repository = self.github.repository(owner, project)
         pull_request = repository.issue(pr_number)
         pull_request.create_comment(message)
+
+    def setCommitStatus(self, owner, project, sha, state,
+                        url='', description='', context=''):
+        repository = self.github.repository(owner, project)
+        repository.create_status(sha, state, url, description, context)
 
 
 def getSchema():

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -472,6 +472,8 @@ class GithubConnection(BaseConnection):
             raise Exception('Multiple pulls found with head sha %s' % sha)
 
         log_rate_limit(self.log, self.github)
+        if len(pulls) == 0:
+            return None
         return pulls.pop()
 
     def getPullFileNames(self, owner, project, number):

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -291,6 +291,10 @@ class GithubConnection(BaseConnection):
     def getPull(self, owner, project, number):
         return self.github.pull_request(owner, project, number).as_dict()
 
+    def getPullFileNames(self, owner, project, number):
+        return [f.filename for f in
+                self.github.pull_request(owner, project, number).files()]
+
     def getUser(self, login):
         return GithubUser(self.github, login)
 

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -220,7 +220,31 @@ class GithubWebhookListener():
 
         event.title = pr_body.get('title')
 
+        # get the statuses
+        owner, project = event.project_name.split('/')
+        event.statuses = self._get_statuses(owner, project, event.patch_number)
+
         return event
+
+    def _get_statuses(self, owner, project, sha):
+        # A ref can have more than one status from each context,
+        # however the API returns them in order, newest first.
+        # So we can keep track of which contexts we've already seen
+        # and throw out the rest. Our unique key is based on
+        # the user and the context, since context is free form and anybody
+        # can put whatever they want there. We want to ensure we track it
+        # by user, so that we can require/trigger by user too.
+        seen = []
+        statuses = []
+        for status in self.connection.getCommitStatuses(owner, project, sha):
+            user = status.get('creator').get('login')
+            context = status.get('context')
+            state = status.get('state')
+            if "%s:%s" % (user, context) not in seen:
+                statuses.append("%s:%s:%s" % (user, context, state))
+                seen.append("%s:%s" % (user, context))
+
+        return statuses
 
     def _get_sender(self, body):
         login = body.get('sender').get('login')
@@ -424,6 +448,16 @@ class GithubConnection(BaseConnection):
         log_rate_limit(self.log, self.github)
         if not result:
             raise Exception('Pull request was not merged')
+
+    def getCommitStatuses(self, owner, project, sha):
+        repository = self.github.repository(owner, project)
+        commit = repository.commit(sha)
+        # make a list out of the statuses so that we complete our
+        # API transaction
+        statuses = [status for status in commit.statuses()]
+
+        log_rate_limit(self.log, self.github)
+        return statuses
 
     def setCommitStatus(self, owner, project, sha, state,
                         url='', description='', context=''):

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -456,7 +456,7 @@ class GithubConnection(BaseConnection):
 
     def getPullBySha(self, sha):
         query = '%s type:pr is:open' % sha
-        pulls = set()
+        pulls = []
         for issue in self.github.search_issues(query=query):
             pr_url = issue.pull_request.get('url')
             if not pr_url:
@@ -466,7 +466,9 @@ class GithubConnection(BaseConnection):
             pr = self.github.pull_request(owner, project, number)
             if pr.head.sha != sha:
                 continue
-            pulls.add(pr.as_dict())
+            if pr.as_dict() in pulls:
+                continue
+            pulls.append(pr.as_dict())
 
         if len(pulls) > 1:
             raise Exception('Multiple pulls found with head sha %s' % sha)

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -1,0 +1,189 @@
+# Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import hmac
+import hashlib
+
+import webob
+import webob.dec
+import voluptuous as v
+import github3
+
+from zuul.connection import BaseConnection
+from zuul.model import TriggerEvent
+
+
+class GithubWebhookListener():
+
+    log = logging.getLogger("zuul.GithubWebhookListener")
+
+    def __init__(self, connection):
+        self.connection = connection
+
+    def handle_request(self, request):
+        if request.method != 'POST':
+            self.log.debug("Only POST method is allowed.")
+            raise webob.exc.HTTPMethodNotAllowed(
+                'Only POST method is allowed.')
+
+        self.log.debug("Github Webhook Received.")
+
+        self._validate_signature(request)
+
+        self.__dispatch_event(request)
+
+    def __dispatch_event(self, request):
+        try:
+            event = request.headers['X-Github-Event']
+            self.log.debug("X-Github-Event: " + event)
+        except KeyError:
+            self.log.debug("Request headers missing the X-Github-Event.")
+            raise webob.exc.HTTPBadRequest('Please specify a X-Github-Event '
+                                           'header.')
+
+        try:
+            method = getattr(self, '_event_' + event)
+        except AttributeError:
+            message = "Unhandled X-Github-Event: {0}".format(event)
+            self.log.debug(message)
+            raise webob.exc.HTTPBadRequest(message)
+
+        try:
+            event = method(request)
+        except:
+            self.log.exception('Exception when handling event:')
+
+        if event:
+            self.log.debug('Scheduling github event: {0}'.format(event.type))
+            self.connection.sched.addEvent(event)
+
+    def _event_pull_request(self, request):
+        body = request.json_body
+        action = body.get('action')
+        pr_body = body.get('pull_request')
+
+        event = self._pull_request_to_event(pr_body)
+
+        if action == 'opened':
+            event.type = 'pr-open'
+        elif action == 'synchronize':
+            event.type = 'pr-change'
+        elif action == 'closed':
+            event.type = 'pr-close'
+        elif action == 'reopened':
+            event.type = 'pr-reopen'
+        else:
+            return None
+
+        return event
+
+    def _validate_signature(self, request):
+        secret = self.connection.connection_config.get('webhook_token', None)
+        if secret is None:
+            return True
+
+        body = request.body
+        try:
+            request_signature = request.headers['X-Hub-Signature']
+        except KeyError:
+            raise webob.exc.HTTPUnauthorized(
+                'Please specify a X-Hub-Signature header with secret.')
+
+        payload_signature = 'sha1=' + hmac.new(secret,
+                                               body,
+                                               hashlib.sha1).hexdigest()
+
+        self.log.debug("Payload Signature: {0}".format(str(payload_signature)))
+        self.log.debug("Request Signature: {0}".format(str(request_signature)))
+        if str(payload_signature) != str(request_signature):
+            raise webob.exc.HTTPUnauthorized(
+                'Request signature does not match calculated payload '
+                'signature. Check that secret is correct.')
+
+        return True
+
+    def _pull_request_to_event(self, pr_body):
+        event = TriggerEvent()
+        event.trigger_name = 'github'
+
+        base = pr_body.get('base')
+        base_repo = base.get('repo')
+        head = pr_body.get('head')
+
+        event.project_name = base_repo.get('full_name')
+        event.change_number = pr_body.get('number')
+        event.change_url = self.connection.getPullUrl(event.project_name,
+                                                      event.change_number)
+        event.updated_at = pr_body.get('updated_at')
+        event.branch = base.get('ref')
+        event.refspec = "refs/pull/" + str(pr_body.get('number')) + "/head"
+        event.patch_number = head.get('sha')
+
+        return event
+
+
+class GithubConnection(BaseConnection):
+    driver_name = 'github'
+    log = logging.getLogger("zuul.GithubConnection")
+    payload_path = 'payload'
+
+    def __init__(self, connection_name, connection_config):
+        super(GithubConnection, self).__init__(
+            connection_name, connection_config)
+        self.github = None
+        self._change_cache = {}
+
+    def onLoad(self):
+        webhook_listener = GithubWebhookListener(self)
+        self.registerHttpHandler(self.payload_path,
+                                 webhook_listener.handle_request)
+        self._authenticateGithubAPI()
+
+    def onStop(self):
+        self.unregisterHttpHandler(self.payload_path)
+
+    def _authenticateGithubAPI(self):
+        token = self.connection_config.get('api_token', None)
+        if token is not None:
+            self.github = github3.login(token)
+            self.log.info("Github API Authentication successful.")
+        else:
+            self.github = None
+            self.log.info(
+                "No Github credentials found in zuul configuration, cannot "
+                "authenticate.")
+
+    def maintainCache(self, relevant):
+        for key, change in self._change_cache.items():
+            if change not in relevant:
+                del self._change_cache[key]
+
+    def getGitUrl(self, project):
+        url = 'https://%s/%s' % ("github.com", project)
+        return url
+
+    def getGitwebUrl(self, project, sha=None):
+        url = 'https://%s/%s' % ("github.com", project)
+        if sha is not None:
+            url += '/commit/%s' % sha
+        return url
+
+    def getPullUrl(self, project, number):
+        return '%s/pull/%s' % (self.getGitwebUrl(project), number)
+
+
+def getSchema():
+    github_connection = v.Any(str, v.Schema({}, extra=True))
+    return github_connection

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -165,6 +165,26 @@ class GithubWebhookListener():
         event.type = 'pr-comment'
         return event
 
+    def _event_pull_request_review(self, request):
+        """Handles pull request reviews"""
+        body = request.json_body
+        action = body.get('action')
+        if action != 'submitted':
+            return
+        pr_body = body.get('pull_request')
+        if pr_body is None:
+            return
+
+        review = body.get('review')
+        if review is None:
+            return
+
+        event = self._pull_request_to_event(pr_body)
+        event.state = review.get('state')
+        event.account = self._get_sender(body)
+        event.type = 'pr-review'
+        return event
+
     def _issue_to_pull_request(self, body):
         number = body.get('issue').get('number')
         project_name = body.get('repository').get('full_name')

--- a/zuul/layoutvalidator.py
+++ b/zuul/layoutvalidator.py
@@ -26,6 +26,7 @@ def toList(x):
 
 
 class LayoutSchema(object):
+
     include = {'python-file': str}
     includes = [include]
 
@@ -163,6 +164,7 @@ class LayoutSchema(object):
         connection_drivers = {
             'trigger': {
                 'gerrit': 'zuul.trigger.gerrit',
+                'github': 'zuul.trigger.github',
             },
             'reporter': {
                 'gerrit': 'zuul.reporter.gerrit',
@@ -280,6 +282,7 @@ class LayoutSchema(object):
 
 
 class LayoutValidator(object):
+
     def checkDuplicateNames(self, data, path):
         items = []
         for i, item in enumerate(data):

--- a/zuul/layoutvalidator.py
+++ b/zuul/layoutvalidator.py
@@ -227,7 +227,7 @@ class LayoutSchema(object):
                 if required_param == 'name':
                     continue
                 # add this template parameters as requirements:
-                schema.update({v.Required(required_param): str})
+                schema.update({v.Required(required_param): toList(str)})
 
             # Register the schema for validateTemplateCalls()
             self.templates_schemas[t_name] = v.Schema(schema)

--- a/zuul/layoutvalidator.py
+++ b/zuul/layoutvalidator.py
@@ -169,6 +169,7 @@ class LayoutSchema(object):
             'reporter': {
                 'gerrit': 'zuul.reporter.gerrit',
                 'smtp': 'zuul.reporter.smtp',
+                'github': 'zuul.reporter.github',
             },
         }
         standard_drivers = {
@@ -301,6 +302,7 @@ class LayoutValidator(object):
             'reporter': {
                 'gerrit': 'zuul.reporter.gerrit',
                 'smtp': 'zuul.reporter.smtp',
+                'github': 'zuul.reporter.github',
             },
         }
         standard_drivers = {

--- a/zuul/lib/connections.py
+++ b/zuul/lib/connections.py
@@ -15,6 +15,7 @@
 import re
 
 import zuul.connection.gerrit
+import zuul.connection.github
 import zuul.connection.smtp
 
 
@@ -43,6 +44,9 @@ def configure_connections(config):
             connections[con_name] = \
                 zuul.connection.gerrit.GerritConnection(con_name,
                                                         con_config)
+        elif con_driver == 'github':
+            connections[con_name] = \
+                zuul.connection.github.GithubConnection(con_name, con_config)
         elif con_driver == 'smtp':
             connections[con_name] = \
                 zuul.connection.smtp.SMTPConnection(con_name, con_config)

--- a/zuul/merger/merger.py
+++ b/zuul/merger/merger.py
@@ -186,6 +186,9 @@ class Repo(object):
         repo = self.createRepoObject()
         self.log.debug("Updating repository %s" % self.local_path)
         origin = repo.remotes.origin
+        # reset the origin url in case it has updated in config
+        # since we last touched it
+        origin.set_url(self.remote_url)
         if repo.git.version_info[:2] < (1, 9):
             # Before 1.9, 'git fetch --tags' did not include the
             # behavior covered by 'git --fetch', so we run both

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -916,7 +916,7 @@ class Changeish(object):
         base_path = ''
         if hasattr(self, 'refspec'):
             base_path = "%s/%s/%s" % (
-                self.number[-2:], self.number, self.patchset)
+                str(self.number)[-2:], self.number, self.patchset)
         elif hasattr(self, 'ref'):
             base_path = "%s/%s" % (self.newrev[:2], self.newrev)
 
@@ -984,6 +984,20 @@ class Change(Changeish):
             related.add(c)
             related.update(c.getRelatedChanges())
         return related
+
+
+class PullRequest(Change):
+    def __init__(self, project):
+        super(PullRequest, self).__init__(project)
+        self.updated_at = None
+
+    def isUpdateOf(self, other):
+        if (hasattr(other, 'number') and self.number == other.number and
+            hasattr(other, 'patchset') and self.patchset != other.patchset and
+            hasattr(other, 'updated_at') and
+            self.updated_at > other.updated_at):
+            return True
+        return False
 
 
 class Ref(Changeish):

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -956,6 +956,8 @@ class Change(Changeish):
         self.status = None
         self.owner = None
 
+        self.source_event = None
+
     def _id(self):
         return '%s,%s' % (self.number, self.patchset)
 
@@ -990,6 +992,7 @@ class PullRequest(Change):
     def __init__(self, project):
         super(PullRequest, self).__init__(project)
         self.updated_at = None
+        self.title = None
 
     def isUpdateOf(self, other):
         if (hasattr(other, 'number') and self.number == other.number and
@@ -1105,6 +1108,10 @@ class TriggerEvent(object):
 
 
 class GithubTriggerEvent(TriggerEvent):
+
+    def __init__(self):
+        super(GithubTriggerEvent, self).__init__()
+        self.title = None
 
     def isPatchsetCreated(self):
         return self.type in ['pr-open', 'pr-change']

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -1091,6 +1091,7 @@ class TriggerEvent(object):
         self.branch = None
         self.comment = None
         self.label = None
+        self.state = None
         # ref-updated
         self.ref = None
         self.oldrev = None
@@ -1232,7 +1233,7 @@ class EventFilter(BaseFilter):
     def __init__(self, trigger, types=[], branches=[], refs=[],
                  event_approvals={}, comments=[], emails=[], usernames=[],
                  timespecs=[], required_approvals=[], reject_approvals=[],
-                 pipelines=[], labels=[], ignore_deletes=True):
+                 pipelines=[], labels=[], states=[], ignore_deletes=True):
         super(EventFilter, self).__init__(
             required_approvals=required_approvals,
             reject_approvals=reject_approvals)
@@ -1254,6 +1255,7 @@ class EventFilter(BaseFilter):
         self.event_approvals = event_approvals
         self.timespecs = timespecs
         self.labels = labels
+        self.states = states
         self.ignore_deletes = ignore_deletes
 
     def __repr__(self):
@@ -1288,6 +1290,8 @@ class EventFilter(BaseFilter):
             ret += ' timespecs: %s' % ', '.join(self.timespecs)
         if self.labels:
             ret += ' labels: %s' % ', '.join(self.labels)
+        if self.states:
+            ret += ' states: %s' % ', '.join(self.states)
         ret += '>'
 
         return ret
@@ -1386,6 +1390,10 @@ class EventFilter(BaseFilter):
 
         # labels are ORed
         if self.labels and event.label not in self.labels:
+            return False
+
+        # states are ORed
+        if self.states and event.state not in self.states:
             return False
 
         return True

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -1097,6 +1097,21 @@ class TriggerEvent(object):
 
         return ret
 
+    def isPatchsetCreated(self):
+        return 'patchset-created' == self.type
+
+    def isChangeAbandoned(self):
+        return 'change-abandoned' == self.type
+
+
+class GithubTriggerEvent(TriggerEvent):
+
+    def isPatchsetCreated(self):
+        return self.type in ['pr-open', 'pr-change']
+
+    def isChangeAbandoned(self):
+        return 'pr-close' == self.type
+
 
 class BaseFilter(object):
     def __init__(self, required_approvals=[], reject_approvals=[]):

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -906,6 +906,12 @@ class Changeish(object):
     def __init__(self, project):
         self.project = project
 
+    def __str__(self):
+        return str(self._id())
+
+    def _id(self):
+        return None
+
     def getBasePath(self):
         base_path = ''
         if hasattr(self, 'refspec'):

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -905,6 +905,7 @@ class Changeish(object):
 
     def __init__(self, project):
         self.project = project
+        self.connection_name = None
 
     def __str__(self):
         return str(self._id())
@@ -1061,6 +1062,7 @@ class TriggerEvent(object):
         self.data = None
         # common
         self.type = None
+        self.connection_name = None
         self.project_name = None
         self.trigger_name = None
         # Representation of the user account that performed the event.

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -1431,8 +1431,19 @@ class ChangeishFilter(BaseFilter):
                 return False
 
         if self.statuses:
-            if change.status not in self.statuses:
-                return False
+            # handle a change where status is list of statuses rather
+            # than a single string
+            if not isinstance(change.status, list):
+                if change.status not in self.statuses:
+                    return False
+            else:
+                # this is likely from github, where the head of the
+                # pr can have multiple statues on it.
+                # If the change statuses and the filter statuses are
+                # a null intersection, there are no matches and we return
+                # false.
+                if set(change.status).isdisjoint(set(self.statuses)):
+                    return False
 
         # required approvals are ANDed (reject approvals are ORed)
         if not self.matchesApprovals(change):

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -1070,6 +1070,7 @@ class TriggerEvent(object):
         self.approvals = []
         self.branch = None
         self.comment = None
+        self.label = None
         # ref-updated
         self.ref = None
         self.oldrev = None
@@ -1192,7 +1193,7 @@ class EventFilter(BaseFilter):
     def __init__(self, trigger, types=[], branches=[], refs=[],
                  event_approvals={}, comments=[], emails=[], usernames=[],
                  timespecs=[], required_approvals=[], reject_approvals=[],
-                 pipelines=[], ignore_deletes=True):
+                 pipelines=[], labels=[], ignore_deletes=True):
         super(EventFilter, self).__init__(
             required_approvals=required_approvals,
             reject_approvals=reject_approvals)
@@ -1213,6 +1214,7 @@ class EventFilter(BaseFilter):
         self.pipelines = [re.compile(x) for x in pipelines]
         self.event_approvals = event_approvals
         self.timespecs = timespecs
+        self.labels = labels
         self.ignore_deletes = ignore_deletes
 
     def __repr__(self):
@@ -1245,6 +1247,8 @@ class EventFilter(BaseFilter):
             ret += ' username_filters: %s' % ', '.join(self._usernames)
         if self.timespecs:
             ret += ' timespecs: %s' % ', '.join(self.timespecs)
+        if self.labels:
+            ret += ' labels: %s' % ', '.join(self.labels)
         ret += '>'
 
         return ret
@@ -1339,6 +1343,10 @@ class EventFilter(BaseFilter):
             if (event.timespec == timespec):
                 matches_timespec = True
         if self.timespecs and not matches_timespec:
+            return False
+
+        # labels are ORed
+        if self.labels and event.label not in self.labels:
             return False
 
         return True

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -14,8 +14,10 @@
 
 import logging
 import voluptuous as v
+import time
 
 from zuul.reporter import BaseReporter
+from zuul.exceptions import MergeFailure
 
 
 class GithubReporter(BaseReporter):
@@ -30,6 +32,7 @@ class GithubReporter(BaseReporter):
         self._github_status_value = None
         self._set_commit_status = self.reporter_config.get('status', False)
         self._create_comment = self.reporter_config.get('comment', False)
+        self._merge = self.reporter_config.get('merge', False)
 
     def postConfig(self):
         github_status_values = {
@@ -48,6 +51,9 @@ class GithubReporter(BaseReporter):
             hasattr(item.change, 'patchset') and
             item.change.patchset is not None):
             self.setPullStatus(pipeline, item)
+        if (self._merge and
+            hasattr(item.change, 'number')):
+            self.mergePull(item)
 
     def addPullComment(self, pipeline, item, message):
         if message is None:
@@ -80,10 +86,25 @@ class GithubReporter(BaseReporter):
         self.connection.setCommitStatus(
             owner, project, sha, state, url, description, context)
 
+    def mergePull(self, item):
+        owner, project = item.change.project.name.split('/')
+        pr_number = item.change.number
+        sha = item.change.patchset
+        self.log.debug('Reporting change %s, params %s, merging via API' %
+                       (item.change, self.reporter_config))
+        try:
+            self.connection.mergePull(owner, project, pr_number, sha)
+        except MergeFailure:
+            time.sleep(2)
+            self.log.debug('Trying to merge change %s again...' % item.change)
+            self.connection.mergePull(owner, project, pr_number, sha)
+        item.change.is_merged = True
+
 
 def getSchema():
     github_reporter = v.Schema({
         'status': bool,
-        'comment': bool
+        'comment': bool,
+        'merge': bool
     })
     return github_reporter

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -58,11 +58,14 @@ class GithubReporter(BaseReporter):
         if (self._merge and
             hasattr(item.change, 'number')):
             self.mergePull(item)
+            if not item.change.is_merged:
+                msg = self._formatItemReportMergeFailure(pipeline, item)
+                self.addPullComment(pipeline, item, msg)
         if self._labels:
             self.setLabels(item)
 
-    def addPullComment(self, pipeline, item):
-        message = self._formatItemReport(pipeline, item)
+    def addPullComment(self, pipeline, item, comment=None):
+        message = comment or self._formatItemReport(pipeline, item)
         owner, project = item.change.project.name.split('/')
         pr_number = item.change.number
         self.log.debug(
@@ -106,13 +109,22 @@ class GithubReporter(BaseReporter):
         self.log.debug('Reporting change %s, params %s, merging via API' %
                        (item.change, self.reporter_config))
         message = self._formatMergeMessage(item.change)
-        try:
-            self.connection.mergePull(owner, project, pr_number, message, sha)
-        except MergeFailure:
-            time.sleep(2)
-            self.log.debug('Trying to merge change %s again...' % item.change)
-            self.connection.mergePull(owner, project, pr_number, message, sha)
-        item.change.is_merged = True
+
+        for i in [1, 2]:
+            try:
+                self.connection.mergePull(owner, project, pr_number, message,
+                                          sha)
+                item.change.is_merged = True
+                return
+            except MergeFailure:
+                self.log.debug(
+                    'Merge attempt of change %s  %s/2 failed.' %
+                    (i, item.change))
+                if i == 1:
+                    time.sleep(2)
+        self.log.debug(
+            'Merge of change %s failed after 2 attempts, giving up' %
+            item.change)
 
     def setLabels(self, item):
         owner, project = item.change.project.name.split('/')

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -1,0 +1,39 @@
+# Copyright 2015 Puppet Labs
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import voluptuous as v
+
+from zuul.reporter import BaseReporter
+
+
+class GithubReporter(BaseReporter):
+    """Sends off reports to Github."""
+
+    name = 'github'
+    log = logging.getLogger("zuul.GithubReporter")
+
+    def report(self, source, pipeline, item, message=None):
+        """Comment on PR with test status."""
+        if message is None:
+            message = self._formatItemReport(pipeline, item)
+        owner, project = item.change.project.name.split("/")
+        pr_number = item.change.number
+
+        self.connection.report(owner, project, pr_number, message)
+
+
+def getSchema():
+    github_reporter = v.Any(str, v.Schema({}, extra=True))
+    return github_reporter

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -78,6 +78,8 @@ class GithubReporter(BaseReporter):
         url = ''
         if self.sched.config.has_option('zuul', 'status_url'):
             url = self.sched.config.get('zuul', 'status_url')
+        if self.sched.config.has_option('zuul', 'status_url_with_change'):
+            url = '%s/#%s' % (url, item.change)
         description = ''
         if pipeline.description:
             description = pipeline.description

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -97,12 +97,13 @@ class GithubReporter(BaseReporter):
         sha = item.change.patchset
         self.log.debug('Reporting change %s, params %s, merging via API' %
                        (item.change, self.reporter_config))
+        message = self._formatMergeMessage(item.change)
         try:
-            self.connection.mergePull(owner, project, pr_number, sha)
+            self.connection.mergePull(owner, project, pr_number, message, sha)
         except MergeFailure:
             time.sleep(2)
             self.log.debug('Trying to merge change %s again...' % item.change)
-            self.connection.mergePull(owner, project, pr_number, sha)
+            self.connection.mergePull(owner, project, pr_number, message, sha)
         item.change.is_merged = True
 
     def setLabels(self, item):
@@ -116,6 +117,33 @@ class GithubReporter(BaseReporter):
                     owner, project, pr_number, label[1:])
             else:
                 self.connection.labelPull(owner, project, pr_number, label)
+
+    def _formatMergeMessage(self, change):
+        message = ''
+
+        if change.title:
+            message += change.title
+
+        account = change.source_event.account
+        if not account:
+            return message
+
+        username = account['username']
+        name = account['name']
+        email = account['email']
+        message += '\n\nReviewed-by: '
+
+        if name:
+            message += name
+        if email:
+            if name:
+                message += ' '
+            message += '<' + email + '>'
+        if name or email:
+            message += '\n             '
+        message += self.connection.getUserUri(username)
+
+        return message
 
 
 def getSchema():

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -321,6 +321,7 @@ class Scheduler(threading.Thread):
         # is useful for not doing a full load during layout validation.
         self.connections = connections
         for connection_name, connection in self.connections.items():
+            logging.debug("Connection: {0}".format(connection_name))
             connection.registerScheduler(self)
             connection.registerWebapp(webapp)
             if load:
@@ -351,9 +352,11 @@ class Scheduler(threading.Thread):
         drivers = {
             'source': {
                 'gerrit': 'zuul.source.gerrit:GerritSource',
+                'github': 'zuul.source.github:GithubSource',
             },
             'trigger': {
                 'gerrit': 'zuul.trigger.gerrit:GerritTrigger',
+                'github': 'zuul.trigger.github:GithubTrigger',
                 'timer': 'zuul.trigger.timer:TimerTrigger',
                 'zuul': 'zuul.trigger.zuultrigger:ZuulTrigger',
             },

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -579,8 +579,12 @@ class Scheduler(threading.Thread):
                         add_jobs(job_tree, x)
                 if isinstance(job, dict):
                     for parent, children in job.items():
-                        parent_tree = job_tree.addJob(layout.getJob(parent))
-                        add_jobs(parent_tree, children)
+                        parent_job = layout.getJob(parent)
+                        parent_tree = job_tree.addJob(parent_job)
+                        if parent_tree is None:
+                            parent_tree = job_tree.getJobTreeForJob(parent_job)
+                        if parent_tree is not None:
+                            add_jobs(parent_tree, children)
                 if isinstance(job, str):
                     job_tree.addJob(layout.getJob(job))
 

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -1780,7 +1780,7 @@ class BasePipelineManager(object):
 
         for change in build.build_set.other_changes:
             concurrent_changes += '<li><a href="{change.url}">\
-              {change.number},{change.patchset}</a></li>'.format(
+              {change}</a></li>'.format(
                 change=change)
 
         change = build.build_set.item.change
@@ -1827,7 +1827,7 @@ class BasePipelineManager(object):
             ret = """\
 <p>
   Triggered by change:
-    <a href="{change.url}">{change.number},{change.patchset}</a><br/>
+    <a href="{change.url}">{change}</a><br/>
   Branch: <b>{change.branch}</b><br/>
   Pipeline: <b>{self.pipeline.name}</b>
 </p>"""

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -316,12 +316,13 @@ class Scheduler(threading.Thread):
             # Any skip-if predicate can be matched to trigger a skip
             return cm.MatchAny(skip_matchers)
 
-    def registerConnections(self, connections, load=True):
+    def registerConnections(self, connections, webapp, load=True):
         # load: whether or not to trigger the onLoad for the connection. This
         # is useful for not doing a full load during layout validation.
         self.connections = connections
         for connection_name, connection in self.connections.items():
             connection.registerScheduler(self)
+            connection.registerWebapp(webapp)
             if load:
                 connection.onLoad()
 

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -1053,17 +1053,24 @@ class Scheduler(threading.Thread):
             project = self.layout.projects.get(event.project_name)
 
             for pipeline in self.layout.pipelines.values():
-                # Get the change even if the project is unknown to us for the
-                # use of updating the cache if there is another change
-                # depending on this foreign one.
-                try:
-                    change = pipeline.source.getChange(event, project)
-                except exceptions.ChangeNotFound as e:
-                    self.log.debug("Unable to get change %s from source %s. "
-                                   "(most likely looking for a change from "
-                                   "another connection trigger)",
-                                   e.change, pipeline.source)
-                    continue
+                if not (event.change_number or event.ref):
+                    change = NullChange(project)
+                else:
+                    if event.connection_name != \
+                       pipeline.source.connection.connection_name:
+                        continue
+                    # Get the change even if the project is unknown to us for
+                    # the use of updating the cache if there is another change
+                    # depending on this foreign one.
+                    try:
+                        change = pipeline.source.getChange(event, project)
+                    except exceptions.ChangeNotFound as e:
+                        self.log.debug(
+                            "Unable to get change %s from source %s. (most "
+                            "likely looking for a change from another "
+                            "connection trigger)",
+                            e.change, pipeline.source)
+                        continue
                 if not project or project.foreign:
                     self.log.debug("Project %s not found" % event.project_name)
                     continue

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -364,6 +364,7 @@ class Scheduler(threading.Thread):
             },
             'reporter': {
                 'gerrit': 'zuul.reporter.gerrit:GerritReporter',
+                'github': 'zuul.reporter.github:GithubReporter',
                 'smtp': 'zuul.reporter.smtp:SMTPReporter',
             },
         }

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -15,7 +15,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import copy
 import extras
+import itertools
 import json
 import logging
 import os
@@ -585,17 +587,40 @@ class Scheduler(threading.Thread):
             project = Project(config_project['name'])
             shortname = config_project['name'].split('/')[-1]
 
+            raw_requested_templates = config_project.get('template', [])
+
+            requested_templates = []
+
+            # Here we expand the requested templates for any key in the project
+            # that is a list to create a "matrix" of jobs for this project.
+            for raw_template in raw_requested_templates:
+                dimensions = []
+
+                for (k, v) in raw_template.items():
+                    if isinstance(v, list):
+                        dimensions.append(zip([k] * len(v), v))
+
+                if len(dimensions) == 0:
+                    requested_templates.append(raw_template)
+                    continue
+
+                for values in itertools.product(*dimensions):
+                    template = copy.deepcopy(raw_template)
+                    for (k, v) in values:
+                        template[k] = v
+                    requested_templates.append(template)
+
             # This is reversed due to the prepend operation below, so
             # the ultimate order is templates (in order) followed by
             # statically defined jobs.
-            for requested_template in reversed(
-                config_project.get('template', [])):
+            for requested_template in reversed(requested_templates):
                 # Fetch the template from 'project-templates'
                 tpl = project_templates.get(
                     requested_template.get('name'))
                 # Expand it with the project context
                 requested_template['name'] = shortname
                 expanded = deep_format(tpl, requested_template)
+
                 # Finally merge the expansion with whatever has been
                 # already defined for this project.  Prepend our new
                 # jobs to existing ones (which may have been

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -1067,9 +1067,9 @@ class Scheduler(threading.Thread):
                 if not project or project.foreign:
                     self.log.debug("Project %s not found" % event.project_name)
                     continue
-                if event.type == 'patchset-created':
+                if event.isPatchsetCreated():
                     pipeline.manager.removeOldVersionsOfChange(change)
-                elif event.type == 'change-abandoned':
+                elif event.isChangeAbandoned():
                     pipeline.manager.removeAbandonedChange(change)
                 if pipeline.manager.eventMatches(event, change):
                     self.log.info("Adding %s, %s to %s" %

--- a/zuul/source/gerrit.py
+++ b/zuul/source/gerrit.py
@@ -16,7 +16,7 @@ import logging
 import re
 import time
 from zuul import exceptions
-from zuul.model import Change, Ref, NullChange
+from zuul.model import Change, Ref
 from zuul.source import BaseSource
 
 
@@ -148,14 +148,13 @@ class GerritSource(BaseSource):
             refresh = False
             change = self._getChange(event.change_number, event.patch_number,
                                      refresh=refresh)
-        elif event.ref:
+        else:
             change = Ref(project)
+            change.connection_name = self.connection.connection_name
             change.ref = event.ref
             change.oldrev = event.oldrev
             change.newrev = event.newrev
             change.url = self._getGitwebUrl(project, sha=event.newrev)
-        else:
-            change = NullChange(project)
         return change
 
     def _getChange(self, number, patchset, refresh=False, history=None):
@@ -165,6 +164,7 @@ class GerritSource(BaseSource):
             return change
         if not change:
             change = Change(None)
+            change.connection_name = self.connection.connection_name
             change.number = number
             change.patchset = patchset
         key = '%s,%s' % (change.number, change.patchset)

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -58,6 +58,7 @@ class GithubSource(BaseSource):
             change.url = event.change_url
             change.updated_at = self._ghTimestampToDate(event.updated_at)
             change.patchset = event.patch_number
+            change.files = self.getPullFiles(project, change.number)
             change.title = event.title
             change.source_event = event
         elif event.ref:
@@ -86,6 +87,11 @@ class GithubSource(BaseSource):
     def getGitwebUrl(self, project, sha=None):
         """Get the git-web url for a project."""
         return self.connection.getGitwebUrl(project, sha)
+
+    def getPullFiles(self, project, number):
+        """Get filenames of the pull request"""
+        owner, project = project.name.split('/')
+        return self.connection.getPullFileNames(owner, project, number)
 
     def _ghTimestampToDate(self, timestamp):
         return time.strptime(timestamp, '%Y-%m-%dT%H:%M:%SZ')

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -1,0 +1,77 @@
+# Copyright 2014 Puppet Labs Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import time
+
+from zuul.model import NullChange, PullRequest
+from zuul.source import BaseSource
+
+
+class GithubSource(BaseSource):
+    name = 'github'
+    log = logging.getLogger("zuul.GithubSource")
+
+    def getRefSha(self, project, ref):
+        """Return a sha for a given project ref."""
+        raise NotImplementedError()
+
+    def waitForRefSha(self, project, ref, old_sha=''):
+        """Block until a ref shows up in a given project."""
+        raise NotImplementedError()
+
+    def isMerged(self, change, head=None):
+        """Determine if change is merged."""
+        raise NotImplementedError()
+
+    def canMerge(self, change, allow_needs):
+        """Determine if change can merge."""
+        raise NotImplementedError()
+
+    def postConfig(self):
+        """Called after configuration has been processed."""
+        pass
+
+    def getChange(self, event, project):
+        """Get the change representing an event."""
+        if event.change_number:
+            change = PullRequest(project)
+            change.number = event.change_number
+            change.refspec = event.refspec
+            change.branch = event.branch
+            change.url = event.change_url
+            change.updated_at = self._ghTimestampToDate(event.updated_at)
+            change.patchset = event.patch_number
+        else:
+            change = NullChange(project)
+        return change
+
+    def getProjectOpenChanges(self, project):
+        """Get the open changes for a project."""
+        raise NotImplementedError()
+
+    def updateChange(self, change, history=None):
+        """Update information for a change."""
+        raise NotImplementedError()
+
+    def getGitUrl(self, project):
+        """Get the git url for a project."""
+        return self.connection.getGitUrl(project)
+
+    def getGitwebUrl(self, project, sha=None):
+        """Get the git-web url for a project."""
+        raise NotImplementedError()
+
+    def _ghTimestampToDate(self, timestamp):
+        return time.strptime(timestamp, '%Y-%m-%dT%H:%M:%SZ')

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -15,7 +15,7 @@
 import logging
 import time
 
-from zuul.model import NullChange, PullRequest
+from zuul.model import NullChange, PullRequest, Ref
 from zuul.source import BaseSource
 
 
@@ -53,6 +53,12 @@ class GithubSource(BaseSource):
             change.url = event.change_url
             change.updated_at = self._ghTimestampToDate(event.updated_at)
             change.patchset = event.patch_number
+        elif event.ref:
+            change = Ref(project)
+            change.ref = event.ref
+            change.oldrev = event.oldrev
+            change.newrev = event.newrev
+            change.url = self.getGitwebUrl(project, sha=event.newrev)
         else:
             change = NullChange(project)
         return change
@@ -71,7 +77,7 @@ class GithubSource(BaseSource):
 
     def getGitwebUrl(self, project, sha=None):
         """Get the git-web url for a project."""
-        raise NotImplementedError()
+        return self.connection.getGitwebUrl(project, sha)
 
     def _ghTimestampToDate(self, timestamp):
         return time.strptime(timestamp, '%Y-%m-%dT%H:%M:%SZ')

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -15,7 +15,7 @@
 import logging
 import time
 
-from zuul.model import NullChange, PullRequest, Ref
+from zuul.model import PullRequest, Ref
 from zuul.source import BaseSource
 
 
@@ -61,15 +61,13 @@ class GithubSource(BaseSource):
             change.files = self.getPullFiles(project, change.number)
             change.title = event.title
             change.source_event = event
-        elif event.ref:
+        else:
             change = Ref(project)
             change.ref = event.ref
             change.oldrev = event.oldrev
             change.newrev = event.newrev
             change.url = self.getGitwebUrl(project, sha=event.newrev)
             change.source_event = event
-        else:
-            change = NullChange(project)
         return change
 
     def getProjectOpenChanges(self, project):

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -19,6 +19,18 @@ from zuul.model import PullRequest, Ref
 from zuul.source import BaseSource
 
 
+# The reviews API is a developer preview.  These are the review states
+# we currently react to. See: https://developer.github.com/v3/pulls/reviews/
+REVIEW_APPROVED = 'APPROVED'
+REVIEW_CHANGES_REQUESTED = 'CHANGES_REQUESTED'
+REVIEW_COMMENTED = 'COMMENTED'
+REVIEW_STATES = [
+    REVIEW_APPROVED,
+    REVIEW_CHANGES_REQUESTED,
+    REVIEW_COMMENTED,
+]
+
+
 class GithubSource(BaseSource):
     name = 'github'
     log = logging.getLogger("zuul.GithubSource")
@@ -105,7 +117,7 @@ class GithubSource(BaseSource):
 
         approvals = []
         for review in reviews:
-            if review.get('state') == 'DISMISSED':
+            if review.get('state') not in REVIEW_STATES:
                 continue
 
             approval = {
@@ -117,7 +129,7 @@ class GithubSource(BaseSource):
             }
 
             # Determine type
-            if review.get('state') == 'COMMENTED':
+            if review.get('state') == REVIEW_COMMENTED:
                 approval['type'] = 'comment'
                 approval['description'] = 'comment'
                 approval['value'] = '0'
@@ -133,12 +145,12 @@ class GithubSource(BaseSource):
                 user_can_write = True
 
             # Determine value
-            if review.get('state') == 'APPROVED':
+            if review.get('state') == REVIEW_APPROVED:
                 if user_can_write:
                     approval['value'] = '2'
                 else:
                     approval['value'] = '1'
-            elif review.get('state') == 'CHANGES_REQUESTED':
+            elif review.get('state') == REVIEW_CHANGES_REQUESTED:
                 if user_can_write:
                     approval['value'] = '-2'
                 else:

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -58,12 +58,15 @@ class GithubSource(BaseSource):
             change.url = event.change_url
             change.updated_at = self._ghTimestampToDate(event.updated_at)
             change.patchset = event.patch_number
+            change.title = event.title
+            change.source_event = event
         elif event.ref:
             change = Ref(project)
             change.ref = event.ref
             change.oldrev = event.oldrev
             change.newrev = event.newrev
             change.url = self.getGitwebUrl(project, sha=event.newrev)
+            change.source_event = event
         else:
             change = NullChange(project)
         return change

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -33,11 +33,16 @@ class GithubSource(BaseSource):
 
     def isMerged(self, change, head=None):
         """Determine if change is merged."""
-        raise NotImplementedError()
+        if not change.number:
+            # Not a pull request, considering merged.
+            return True
+        return change.is_merged
 
     def canMerge(self, change, allow_needs):
-        """Determine if change can merge."""
-        raise NotImplementedError()
+        """Determine if change can merge.
+
+        Github does not have any voting system, all pull requests can merge."""
+        return True
 
     def postConfig(self):
         """Called after configuration has been processed."""

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -105,6 +105,9 @@ class GithubSource(BaseSource):
 
         approvals = []
         for review in reviews:
+            if review.get('state') == 'DISMISSED':
+                continue
+
             approval = {
                 'by': {
                     'username': review.get('user').get('login'),
@@ -114,7 +117,7 @@ class GithubSource(BaseSource):
             }
 
             # Determine type
-            if review.get('state') == 'COMMENT':
+            if review.get('state') == 'COMMENTED':
                 approval['type'] = 'comment'
                 approval['description'] = 'comment'
                 approval['value'] = '0'
@@ -130,12 +133,12 @@ class GithubSource(BaseSource):
                 user_can_write = True
 
             # Determine value
-            if review.get('state') == 'APPROVE':
+            if review.get('state') == 'APPROVED':
                 if user_can_write:
                     approval['value'] = '2'
                 else:
                     approval['value'] = '1'
-            elif review.get('state') == 'REQUEST_CHANGES':
+            elif review.get('state') == 'CHANGES_REQUESTED':
                 if user_can_write:
                     approval['value'] = '-2'
                 else:

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -60,6 +60,7 @@ class GithubSource(BaseSource):
             change.patchset = event.patch_number
             change.files = self.getPullFiles(project, change.number)
             change.title = event.title
+            change.status = event.statuses
             change.source_event = event
         else:
             change = Ref(project)

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -34,9 +34,11 @@ class GithubTrigger(BaseTrigger):
         for trigger in self._toList(trigger_config):
             types = trigger.get('event', None)
             comments = self._toList(trigger.get('comment'))
+            labels = self._toList(trigger.get('label'))
             f = EventFilter(trigger=self,
                             types=self._toList(types),
-                            comments=comments)
+                            comments=comments,
+                            labels=labels)
             efilters.append(f)
 
         return efilters
@@ -56,10 +58,12 @@ def getSchema():
                      'pr-close',
                      'pr-reopen',
                      'pr-comment',
+                     'pr-label',
                      'push',
                      'tag',
                      )),
         'comment': toList(str),
+        'label': toList(str),
     }
 
     logging.debug("github_trigger")

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -38,7 +38,8 @@ class GithubTrigger(BaseTrigger):
                 branches=toList(trigger.get('branch')),
                 refs=toList(trigger.get('ref')),
                 comments=toList(trigger.get('comment')),
-                labels=toList(trigger.get('label'))
+                labels=toList(trigger.get('label')),
+                states=toList(trigger.get('state'))
             )
             efilters.append(f)
 
@@ -60,6 +61,7 @@ def getSchema():
                      'pr-reopen',
                      'pr-comment',
                      'pr-label',
+                     'pr-review',
                      'push',
                      'tag',
                      )),
@@ -67,6 +69,7 @@ def getSchema():
         'ref': toList(str),
         'comment': toList(str),
         'label': toList(str),
+        'state': toList(str),
     }
 
     logging.debug("github_trigger")

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -22,23 +22,24 @@ class GithubTrigger(BaseTrigger):
     name = 'github'
     log = logging.getLogger("zuul.GithubTrigger")
 
-    def _toList(self, item):
-        if not item:
-            return []
-        if isinstance(item, list):
-            return item
-        return [item]
-
     def getEventFilters(self, trigger_config):
+        def toList(item):
+            if not item:
+                return []
+            if isinstance(item, list):
+                return item
+            return [item]
+
         efilters = []
-        for trigger in self._toList(trigger_config):
-            types = trigger.get('event', None)
-            comments = self._toList(trigger.get('comment'))
-            labels = self._toList(trigger.get('label'))
-            f = EventFilter(trigger=self,
-                            types=self._toList(types),
-                            comments=comments,
-                            labels=labels)
+        for trigger in toList(trigger_config):
+            f = EventFilter(
+                trigger=self,
+                types=toList(trigger['event']),
+                branches=toList(trigger.get('branch')),
+                refs=toList(trigger.get('ref')),
+                comments=toList(trigger.get('comment')),
+                labels=toList(trigger.get('label'))
+            )
             efilters.append(f)
 
         return efilters
@@ -62,6 +63,8 @@ def getSchema():
                      'push',
                      'tag',
                      )),
+        'branch': toList(str),
+        'ref': toList(str),
         'comment': toList(str),
         'label': toList(str),
     }

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -33,8 +33,10 @@ class GithubTrigger(BaseTrigger):
         efilters = []
         for trigger in self._toList(trigger_config):
             types = trigger.get('event', None)
+            comments = self._toList(trigger.get('comment'))
             f = EventFilter(trigger=self,
-                            types=self._toList(types))
+                            types=self._toList(types),
+                            comments=comments)
             efilters.append(f)
 
         return efilters
@@ -53,9 +55,11 @@ def getSchema():
                      'pr-change',
                      'pr-close',
                      'pr-reopen',
+                     'pr-comment',
                      'push',
                      'tag',
                      )),
+        'comment': toList(str),
     }
 
     logging.debug("github_trigger")

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -39,7 +39,8 @@ class GithubTrigger(BaseTrigger):
                 refs=toList(trigger.get('ref')),
                 comments=toList(trigger.get('comment')),
                 labels=toList(trigger.get('label')),
-                states=toList(trigger.get('state'))
+                states=toList(trigger.get('state')),
+                statuses=toList(trigger.get('status'))
             )
             efilters.append(f)
 
@@ -63,6 +64,7 @@ def getSchema():
                      'pr-label',
                      'pr-review',
                      'push',
+                     'status',
                      'tag',
                      )),
         'branch': toList(str),
@@ -70,6 +72,7 @@ def getSchema():
         'comment': toList(str),
         'label': toList(str),
         'state': toList(str),
+        'status': toList(str)
     }
 
     logging.debug("github_trigger")

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -53,6 +53,8 @@ def getSchema():
                      'pr-change',
                      'pr-close',
                      'pr-reopen',
+                     'push',
+                     'tag',
                      )),
     }
 

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -1,0 +1,60 @@
+# Copyright 2015 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import voluptuous as v
+from zuul.model import EventFilter
+from zuul.trigger import BaseTrigger
+
+
+class GithubTrigger(BaseTrigger):
+    name = 'github'
+    log = logging.getLogger("zuul.GithubTrigger")
+
+    def _toList(self, item):
+        if not item:
+            return []
+        if isinstance(item, list):
+            return item
+        return [item]
+
+    def getEventFilters(self, trigger_config):
+        efilters = []
+        for trigger in self._toList(trigger_config):
+            types = trigger.get('event', None)
+            f = EventFilter(trigger=self,
+                            types=self._toList(types))
+            efilters.append(f)
+
+        return efilters
+
+    def onPullRequest(self, payload):
+        pass
+
+
+def getSchema():
+    def toList(x):
+        return v.Any([x], x)
+
+    github_trigger = {
+        v.Required('event'):
+        toList(v.Any('pr-open',
+                     'pr-change',
+                     'pr-close',
+                     'pr-reopen',
+                     )),
+    }
+
+    logging.debug("github_trigger")
+    return github_trigger

--- a/zuul/trigger/zuultrigger.py
+++ b/zuul/trigger/zuultrigger.py
@@ -82,6 +82,7 @@ class ZuulTrigger(BaseTrigger):
     def _createProjectChangeMergedEvent(self, change):
         event = TriggerEvent()
         event.type = 'project-change-merged'
+        event.connection_name = change.connection_name
         event.trigger_name = self.name
         event.project_name = change.project.name
         event.change_number = change.number
@@ -102,6 +103,7 @@ class ZuulTrigger(BaseTrigger):
     def _createParentChangeEnqueuedEvent(self, change, pipeline):
         event = TriggerEvent()
         event.type = 'parent-change-enqueued'
+        event.connection_name = change.connection_name
         event.trigger_name = self.name
         event.pipeline_name = pipeline.name
         event.project_name = change.project.name

--- a/zuul/webapp.py
+++ b/zuul/webapp.py
@@ -42,7 +42,7 @@ array of changes, they will not include the queue structure.
 
 class WebApp(threading.Thread):
     log = logging.getLogger("zuul.WebApp")
-    change_path_regexp = '/status/change/(\d+,\d+)$'
+    change_path_regexp = '/status/change/(.*)$'
 
     def __init__(self, scheduler, port=8001, cache_expiry=1,
                  listen_address='0.0.0.0'):


### PR DESCRIPTION
Installation ids are not saved statically in the config file. Rearrange the
github connection so that it saves a project to installation id mapping and
authenticates with the correct information each time.

This is a split up version of what I've tested in production, but this itself
hasn't been tested. However it passes unit tests and integration stuff in
general doesn't work as it is now so hopefully this one is easy to merge and we
can continue to do fixups.