### PR TITLE
Add jenkins-job-builder dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ six>=1.6.0
 pyjwt
 cryptography
 iso8601
+jenkins-job-builder>1.6.0,<2.0


### PR DESCRIPTION
For some reason JJB isn't a direct dependency of zuul and deployment
installs it seperately. This is unnecessary and seems to result in some
churn in playbooks. Add the dependency.

Change-Id: I5662e54d3ea739deacf5007b009698bf7bc3105c
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>