### PR TITLE
Install github3 from commit hash only in testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 pbr>=1.1.0
 
-# pull from master until https://github.com/sigmavirus24/github3.py/pull/671
-# is in a release
--e git://github.com/sigmavirus24/github3.py.git@develop#egg=Github3.py
 PyYAML>=3.1.0
 Paste<2.0
 WebOb>=1.2.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,10 @@
 hacking>=0.9.2,<0.10
 
+# We need https://github.com/sigmavirus24/github3.py/pull/671 which is not yet
+# in a release. This is only  in testing because pip install -U . does not
+# respect pulling from git and so is installed manually in deployment.
+-e git+https://github.com/sigmavirus24/github3.py.git@8e9ca0056b8fed956b66dafb5398757cd8d8bed9#egg=Github3.py
+
 coverage>=3.6
 sphinx>=1.1.2,!=1.2.0,!=1.3b1,<1.3
 sphinxcontrib-blockdiag>=1.1.0


### PR DESCRIPTION
pip install -U . doesn't respect installing from git, so in production
we are ending up with 0.9.6 being installed. This has worked in testing
because pip install -r does work.

We only install this in testing now so that we don't have versions
churning between the pip install zuul and install github3 points.

Change-Id: I5bf6ae532210aa37c2e89e4cb7dfcb8e4ec76e69
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>