### PR TITLE
Cap GitPython at 2.1.1 due to performance degradation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ PyYAML>=3.1.0
 Paste<2.0
 WebOb>=1.2.3
 paramiko>=1.8.0,<2.0.0
-GitPython>=0.3.3
+GitPython>=0.3.3,<2.1.2
 ordereddict
 python-daemon>=2.0.4,<2.1.0
 extras


### PR DESCRIPTION
It appears newer versions of GitPython have slowed considerably.
Cap GitPython until https://github.com/gitpython-developers/GitPython/issues/605
is resolved.