### PR TITLE
Catch integration key file not found in zuul

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -391,8 +391,12 @@ class GithubConnection(BaseConnection):
             self._github.login(token=api_token)
 
         if integration_key_file:
-            with open(integration_key_file, 'r') as f:
-                integration_key = f.read()
+            try:
+                with open(integration_key_file, 'r') as f:
+                    integration_key = f.read()
+            except IOError:
+                m = "Failed to open integration key file for reading: %s"
+                self.log.error(m, integration_key_file)
 
         if (integration_id or integration_key) and \
                 not (integration_id and integration_key):


### PR DESCRIPTION
If the integration key file is not found this raises an uncaught IOError
that basically crashes zuul's main thread and prevents startup. This
exception is unfortunately never logged and so difficult to diagnose.

Change-Id: I78d35cce0ea8f4c4bf6662a38138bef245adafb9
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>