### PR TITLE
Add cachecontrol to requests to github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pyjwt
 cryptography
 iso8601
 jenkins-job-builder>1.6.0,<2.0
+cachecontrol


### PR DESCRIPTION
Github is very strict about quotas per authentication. To prevent going
over these quotas and to ensure we don't get marked as spam we should
make sure to respect the Etags present in responses.

Use cachecontrol to give us a caching layer that will fullfil requests
that are cachable without going over the network.

A point to consider here is that there does not appear to be a way to
vary caching based on the current authentication - so any per auth
requests may be mishandled or auth may expire. I don't think there is
any concern here as it's simply zuul making the requests.

Fixes: BonnyCI/projman#203
Change-Id: I04bfc0cfec1ffc8ebdfd2d9181ac3119cc6e14ac
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>