### PR TITLE
Make anne-bonny and bonnyci[bot] equivalent

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -322,7 +322,9 @@ class GithubWebhookListener():
         if not creator:
             user = "Unknown"
         else:
-            user = creator.get('login')
+            user = creator.get('login', '')
+
+        user = user.replace('anne-bonny', 'bonnyci[bot]')
         context = status.get('context')
         state = status.get('state')
         return (user, context, state)

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -32,6 +32,9 @@ class GithubTrigger(BaseTrigger):
 
         efilters = []
         for trigger in toList(trigger_config):
+            statuses = [s.replace('anne-bonny', 'bonnyci[bot]')
+                        for s in toList(trigger.get('status'))]
+
             f = EventFilter(
                 trigger=self,
                 types=toList(trigger['event']),
@@ -40,7 +43,7 @@ class GithubTrigger(BaseTrigger):
                 comments=toList(trigger.get('comment')),
                 labels=toList(trigger.get('label')),
                 states=toList(trigger.get('state')),
-                event_statuses=toList(trigger.get('status'))
+                event_statuses=statuses
             )
             efilters.append(f)
 


### PR DESCRIPTION
In the BonnyCI migration to using integrations the role of anne-bonny
will hereafter be played by bonnyci[bot]. To ease this transition treat
any reference in config or status to anne-bonny as equivalent to
bonnyci[bot].

This is not a long term good idea, but will let us do the transition and
revert this patch in a week or so.

Change-Id: I9b144c2b978eb82fcee42c08c60cde8142abd02a
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>