### PR TITLE
Add bonnyci.org link to merge-failure-message

### DIFF
--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -74,7 +74,7 @@ pipelines:
     description: Pipeline for merging the pull request
     manager: IndependentPipelineManager
     source: github
-    merge-failure-message: 'Merge failed'
+    merge-failure-message: 'Merge Failed! Help can be found at https://bonnyci.org/lore/end_users/use/#handling-merge-failures'
     trigger:
       github:
         - event: pr-comment

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -356,7 +356,9 @@ class TestGithub(ZuulTestCase):
         self.waitUntilSettled()
         self.assertFalse(A.is_merged)
         self.assertEqual(len(A.comments), 1)
-        self.assertEqual(A.comments[0], 'Merge failed')
+        self.assertEqual(A.comments[0], 'Merge Failed! Help can be found at '
+                                        'https://bonnyci.org/lore/end_users/'
+                                        'use/#handling-merge-failures')
 
     def test_parallel_changes(self):
         "Test that changes are tested in parallel and merged in series"


### PR DESCRIPTION
We should direct users to a place with some documentation on where to
get help on resolving merge failures.

Implements: BonnyCI/projman#199
Depends-On: BonnyCI/bonnyci.org#57

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>