### PR TITLE
Retry github api commands that fail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ cryptography
 iso8601
 jenkins-job-builder>1.6.0,<2.0
 cachecontrol
+tenacity


### PR DESCRIPTION
GitHub api requests should be retried on failure. This uses tenacity
to wrap most of the functions in connection/github.py with a retry
decorator. The retry limit is set to 3, and functions which have a
single exception type are only retried when that exception type is
raised.

Implements: BonnyCI/projman#200

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>