### PR TITLE
Cherry-pick commits from upstream feature/zuulv3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ordereddict
 python-daemon>=2.0.4,<2.1.0
 extras
 statsd>=1.0.0,<3.0
-voluptuous>=0.7
+voluptuous>=0.10.2
 gear>=0.5.7,<1.0.0
 apscheduler>=3.0
 PrettyTable>=0.6,<0.8

--- a/zuul/connection/gerrit.py
+++ b/zuul/connection/gerrit.py
@@ -476,5 +476,5 @@ class GerritConnection(BaseConnection):
 
 
 def getSchema():
-    gerrit_connection = v.Any(str, v.Schema({}, extra=True))
+    gerrit_connection = v.Any(str, v.Schema(dict))
     return gerrit_connection

--- a/zuul/connection/smtp.py
+++ b/zuul/connection/smtp.py
@@ -59,5 +59,5 @@ class SMTPConnection(BaseConnection):
 
 
 def getSchema():
-    smtp_connection = v.Any(str, v.Schema({}, extra=True))
+    smtp_connection = v.Any(str, v.Schema(dict))
     return smtp_connection

--- a/zuul/layoutvalidator.py
+++ b/zuul/layoutvalidator.py
@@ -40,7 +40,7 @@ class LayoutSchema(object):
                          'email': str,
                          'older-than': str,
                          'newer-than': str,
-                         }, extra=True)
+                         }, extra=v.ALLOW_EXTRA)
 
     require = {'approval': toList(approval),
                'open': bool,

--- a/zuul/reporter/gerrit.py
+++ b/zuul/reporter/gerrit.py
@@ -48,5 +48,5 @@ class GerritReporter(BaseReporter):
 
 
 def getSchema():
-    gerrit_reporter = v.Any(str, v.Schema({}, extra=True))
+    gerrit_reporter = v.Any(str, v.Schema(dict))
     return gerrit_reporter

--- a/zuul/trigger/gerrit.py
+++ b/zuul/trigger/gerrit.py
@@ -82,14 +82,14 @@ def validate_conf(trigger_conf):
 def getSchema():
     def toList(x):
         return v.Any([x], x)
-    variable_dict = v.Schema({}, extra=True)
+    variable_dict = v.Schema(dict)
 
     approval = v.Schema({'username': str,
                          'email-filter': str,
                          'email': str,
                          'older-than': str,
                          'newer-than': str,
-                         }, extra=True)
+                         }, extra=v.ALLOW_EXTRA)
 
     gerrit_trigger = {
         v.Required('event'):

--- a/zuul/trigger/zuultrigger.py
+++ b/zuul/trigger/zuultrigger.py
@@ -136,7 +136,7 @@ def getSchema():
                          'email': str,
                          'older-than': str,
                          'newer-than': str,
-                         }, extra=True)
+                         }, extra=v.ALLOW_EXTRA)
 
     zuul_trigger = {
         v.Required('event'):


### PR DESCRIPTION
As discussed with @j2sol in irc, there were some v3 changes to the voluptuous schema that we need to cherry pick into our fork.

**Note**: `0a38b6c` includes some code to `zuul/connection/sql.py` , a file that we have deleted on this branch of our fork. I left it out of the cherry-pick.

Resolves: BonnyCI/projman#213