### PR TITLE
Actually filter status triggers

### DIFF
--- a/zuul/model.py
+++ b/zuul/model.py
@@ -1252,11 +1252,11 @@ class EventFilter(BaseFilter):
     def __init__(self, trigger, types=[], branches=[], refs=[],
                  event_approvals={}, comments=[], emails=[], usernames=[],
                  timespecs=[], required_approvals=[], reject_approvals=[],
-                 pipelines=[], labels=[], states=[], statuses=[],
+                 pipelines=[], labels=[], states=[], event_statuses=[],
                  ignore_deletes=True):
         super(EventFilter, self).__init__(
             required_approvals=required_approvals,
-            reject_approvals=reject_approvals, statuses=statuses)
+            reject_approvals=reject_approvals)
         self.trigger = trigger
         self._types = types
         self._branches = branches
@@ -1277,6 +1277,7 @@ class EventFilter(BaseFilter):
         self.labels = labels
         self.states = states
         self.ignore_deletes = ignore_deletes
+        self.event_statuses = event_statuses
 
     def __repr__(self):
         ret = '<EventFilter'
@@ -1312,8 +1313,8 @@ class EventFilter(BaseFilter):
             ret += ' labels: %s' % ', '.join(self.labels)
         if self.states:
             ret += ' states: %s' % ', '.join(self.states)
-        if self.statuses:
-            ret += ' statuses: %s' % ', '.join(self.statuses)
+        if self.event_statuses:
+            ret += ' event_statuses: %s' % ', '.join(self.event_statuses)
         ret += '>'
 
         return ret
@@ -1418,8 +1419,10 @@ class EventFilter(BaseFilter):
         if self.states and event.state not in self.states:
             return False
 
-        if not self.matchesStatuses(change):
-            return False
+        # statuses are ORed
+        if self.event_statuses:
+            if event.event_status not in self.event_statuses:
+                return False
 
         return True
 

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -40,7 +40,7 @@ class GithubTrigger(BaseTrigger):
                 comments=toList(trigger.get('comment')),
                 labels=toList(trigger.get('label')),
                 states=toList(trigger.get('state')),
-                statuses=toList(trigger.get('status'))
+                event_statuses=toList(trigger.get('status'))
             )
             efilters.append(f)
 


### PR DESCRIPTION
The existing code did not filter on the status being set on the event
itself, it was only looking at (all) the statuses that exist on the change.
This led to false triggers, where an entity was setting an unrelated
status, but the pipeline would trigger because a required status (which
was the trigger status) was already set.

A new test case has been added to cover this scenario.

I also noticed that the calls to fake_github.emitEvent were wrong. The
argument being passed in (presumably for status) was actually setting
the context.

Fixes BonnyCI/projman#124

Change-Id: I694ecc72d962b8cc035ce408bb6e5628b5fdbc49