### PR TITLE
Prevent traceback on unknown pull request

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -539,9 +539,11 @@ class GithubConnection(BaseConnection):
     @retry(stop=stop_after_attempt(RETRY_LIMIT))
     def getPull(self, owner, project, number):
         github = self.getGithubClient("%s/%s" % (owner, project))
-        pr = github.pull_request(owner, project, number).as_dict()
+        pr = github.pull_request(owner, project, number)
         log_rate_limit(self.log, github)
-        return pr
+        if not pr:
+            return None
+        return pr.as_dict()
 
     @retry(stop=stop_after_attempt(RETRY_LIMIT))
     def getPullBySha(self, sha):


### PR DESCRIPTION
We were calling as_dict() on something that could be a None.

Fixes: BonnyCI/projman#118

Change-Id: I32623d71c58418933dba35f139813dc039f909c8
Signed-off-by: Jesse Keating <omgjlk@us.ibm.com>