### PR TITLE
Add logging when webhook signature check fails

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -253,6 +253,7 @@ class GithubWebhookListener():
         try:
             request_signature = request.headers['X-Hub-Signature']
         except KeyError:
+            self.log.debug('Recieved webhook without signature. Ignoring.')
             raise webob.exc.HTTPUnauthorized(
                 'Please specify a X-Hub-Signature header with secret.')
 
@@ -263,6 +264,7 @@ class GithubWebhookListener():
         self.log.debug("Payload Signature: {0}".format(str(payload_signature)))
         self.log.debug("Request Signature: {0}".format(str(request_signature)))
         if str(payload_signature) != str(request_signature):
+            self.log.debug('Recieved webhook with bad signature. Ignoring.')
             raise webob.exc.HTTPUnauthorized(
                 'Request signature does not match calculated payload '
                 'signature. Check that secret is correct.')


### PR DESCRIPTION
When the webhook signature validation fails it returns a failure message
as a response but it doesn't make a record in our logging of a failure.
We should emit something just so we can see a request was handled and
rejected.

Change-Id: I5c6a932a2b7054a40e9228093312980251848191
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>