### PR TITLE
Revert "Make anne-bonny and bonnyci[bot] equivalent"

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -322,9 +322,7 @@ class GithubWebhookListener():
         if not creator:
             user = "Unknown"
         else:
-            user = creator.get('login', '')
-
-        user = user.replace('anne-bonny', 'bonnyci[bot]')
+            user = creator.get('login')
         context = status.get('context')
         state = status.get('state')
         return (user, context, state)

--- a/zuul/trigger/github.py
+++ b/zuul/trigger/github.py
@@ -32,9 +32,6 @@ class GithubTrigger(BaseTrigger):
 
         efilters = []
         for trigger in toList(trigger_config):
-            statuses = [s.replace('anne-bonny', 'bonnyci[bot]')
-                        for s in toList(trigger.get('status'))]
-
             f = EventFilter(
                 trigger=self,
                 types=toList(trigger['event']),
@@ -43,7 +40,7 @@ class GithubTrigger(BaseTrigger):
                 comments=toList(trigger.get('comment')),
                 labels=toList(trigger.get('label')),
                 states=toList(trigger.get('state')),
-                event_statuses=statuses
+                event_statuses=toList(trigger.get('status'))
             )
             efilters.append(f)
 


### PR DESCRIPTION
This reverts commit 37a1db8c683779dfecda007e9efe3a9feaeb4543.

This commit was useful in the transition to using github integrations
but can be removed now that has finished.

Change-Id: I5b2684c926d504effb5625217ffd0ea8873c16ca
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>