### PR TITLE
Report to pulls with identical SHAs

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -565,6 +565,10 @@ class GithubConnection(BaseConnection):
             pulls.append(pr.as_dict())
 
         if len(pulls) > 1:
+            for pull in pulls:
+                self.commentPull(pull.owner, pull.project, pull.pr_number,
+                                 'Multiple pulls found with head sha %s. '
+                                 'Please amend your change.' % sha)
             raise Exception('Multiple pulls found with head sha %s' % sha)
 
         log_rate_limit(self.log, github)


### PR DESCRIPTION
It is possible to run into a scenario where two different pulls have
the same SHA. We should report to these pulls and tell them to amend
their change.

Implements: BonnyCI/projman#127

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>