### PR TITLE
Fix parsing of github PR url

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -584,7 +584,7 @@ class GithubConnection(BaseConnection):
             if not pr_url:
                 continue
             # the issue provides no good description of the project :\
-            owner, project, _, number = pr_url.split('/')[4:]
+            owner, project, _, number = pr_url.split('/')[-4:]
             github = self.getGithubClient("%s/%s" % (owner, project))
             pr = github.pull_request(owner, project, number)
             if pr.head.sha != sha:


### PR DESCRIPTION
We parse the owner, project and PR number of a github PR out of the
PR URL.  When using github enterprise, the path preceding
$org/$repo/pulls/$number in the URL may contain some extra stuff which breaks
the parsing here. This fixes the parsing to parse that info from the end of
the string regardless.

This has been submitted to zuul v3 upstream @ https://review.openstack.org/476286

Signed-off-by: Adam Gandelman <adamg@ubuntu.com>