### PR TITLE
Support customization of context reported

### DIFF
--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -24,6 +24,34 @@ pipelines:
         status: true
         comment: true
 
+  - name: context-check
+    description: Check with custom context
+    manager: IndependentPipelineManager
+    source: github
+    trigger:
+      github:
+        - event:
+            - pr-open
+            - pr-change
+            - pr-reopen
+          branch: '^master$'
+        - event: pr-comment
+          comment: 'test me'
+    start:
+      github:
+        status: true
+        context: continuous-integration/zuul/check
+    success:
+      github:
+        status: true
+        context: continuous-integration/zuul/check
+        comment: true
+    failure:
+      github:
+        status: true
+        context: continuous-integration/zuul/check
+        comment: true
+
   - name: gate
     description: Gatekeeping
     manager: DependentPipelineManager
@@ -168,3 +196,7 @@ projects:
   - name: org/project1
     check:
       - project-testfile
+
+  - name: org/project2
+    context-check:
+      - project-testcontext

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -35,6 +35,7 @@ class GithubReporter(BaseReporter):
         self._create_comment = self.reporter_config.get('comment', False)
         self._merge = self.reporter_config.get('merge', False)
         self._labels = self.reporter_config.get('label', [])
+        self._context = self.reporter_config.get('context', '')
         if not isinstance(self._labels, list):
             self._labels = [self._labels]
 
@@ -76,7 +77,7 @@ class GithubReporter(BaseReporter):
     def setPullStatus(self, pipeline, item):
         owner, project = item.change.project.name.split('/')
         sha = item.change.patchset
-        context = pipeline.name
+        context = self._context or pipeline.name
         state = self._github_status_value
 
         url = ''
@@ -172,6 +173,7 @@ def getSchema():
 
     github_reporter = v.Schema({
         'status': bool,
+        'context': str,
         'comment': bool,
         'merge': bool,
         'label': toList(str),


### PR DESCRIPTION
Allow for custom context to be reported back with the GitHub reporter in
advance of migration to zuulv3 to facilitate merging of separately named
pipelines for Gerrit/GitHub (check/check-github) into a single pipeline
while providing the same context back to GitHub projects to avoid
needing to update the required status checks.